### PR TITLE
Jellyfin port: Fix logging throughout 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,5 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+plugins/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+ARG DOTNET_VERSION=2
+
+
+FROM microsoft/dotnet:${DOTNET_VERSION}-sdk as builder
+WORKDIR /repo
+COPY . .
+RUN export DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+ && dotnet clean \
+ && dotnet publish --configuration release --framework netstandard2.0 --output /plugins

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: build
+build:
+	docker build -t $(USERNAME)/jellyfin-plugin-trakt .
+	docker run -v $(PWD)/plugins:/mnt $(USERNAME)/jellyfin-plugin-trakt \
+		cp -a /plugins/Microsoft.Extensions.Logging.dll \
+			/plugins/Trakt.dll /mnt/

--- a/Trakt/Api/ServerApiEndpoints.cs
+++ b/Trakt/Api/ServerApiEndpoints.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Logging;
+using Microsoft.Extensions.Logging;
 using MediaBrowser.Model.Services;
 using Trakt.Helpers;
 
@@ -134,13 +134,13 @@ namespace Trakt.Api
         /// <returns></returns>
         public object Post(RateItem request)
         {
-            _logger.Info("RateItem request received");
+            _logger.LogInformation("RateItem request received");
 
             var currentItem = _libraryManager.GetItemById(request.Id);
 
             if (currentItem == null)
             {
-                _logger.Info("currentItem is null");
+                _logger.LogInformation("currentItem is null");
                 return null;
             }
 
@@ -157,7 +157,7 @@ namespace Trakt.Api
         /// <returns></returns>
         public object Post(CommentItem request)
         {
-            _logger.Info("CommentItem request received");
+            _logger.LogInformation("CommentItem request received");
 
             var currentItem = _libraryManager.GetItemById(request.Id);
 

--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Logging;
+using Microsoft.Extensions.Logging;
 using MediaBrowser.Model.Serialization;
 using Trakt.Api.DataContracts;
 using Trakt.Api.DataContracts.BaseModel;
@@ -944,7 +944,7 @@ namespace Trakt.Api
             }
             else
             {
-                _logger.Error("Tried to reauthenticate with Trakt, but neither PIN nor refreshToken was available");
+                _logger.LogError("Tried to reauthenticate with Trakt, but neither PIN nor refreshToken was available");
             }
 
             TraktUserToken userToken;
@@ -1004,7 +1004,7 @@ namespace Trakt.Api
             TraktUser traktUser)
         {
             var requestContent = data == null ? string.Empty : _jsonSerializer.SerializeToString(data);
-            if (traktUser != null && traktUser.ExtraLogging) _logger.Debug(requestContent);
+            if (traktUser != null && traktUser.ExtraLogging) _logger.LogDebug(requestContent);
             var options = GetHttpRequestOptions();
             options.Url = url;
             options.CancellationToken = cancellationToken;

--- a/Trakt/Helpers/LibraryManagerEventsHelper.cs
+++ b/Trakt/Helpers/LibraryManagerEventsHelper.cs
@@ -7,7 +7,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Logging;
+using Microsoft.Extensions.Logging;
 using MediaBrowser.Model.Threading;
 using Trakt.Api;
 using Trakt.Model;
@@ -81,17 +81,17 @@ namespace Trakt.Helpers
             }
             catch (Exception ex)
             {
-                _logger.ErrorException("Error in OnQueueTimerCallbackInternal", ex);
+                _logger.LogError("Error in OnQueueTimerCallbackInternal", ex);
             }
         }
 
         private async Task OnQueueTimerCallbackInternal()
         {
-            _logger.Info("Timer elapsed - Processing queued items");
+            _logger.LogInformation("Timer elapsed - Processing queued items");
 
             if (!_queuedEvents.Any())
             {
-                _logger.Info("No events... Stopping queue timer");
+                _logger.LogInformation("No events... Stopping queue timer");
                 // This may need to go
                 return;
             }
@@ -106,12 +106,12 @@ namespace Trakt.Helpers
 
                 if (queuedMovieDeletes.Any())
                 {
-                    _logger.Info(queuedMovieDeletes.Count + " Movie Deletes to Process");
+                    _logger.LogInformation(queuedMovieDeletes.Count + " Movie Deletes to Process");
                     await ProcessQueuedMovieEvents(queuedMovieDeletes, traktUser, EventType.Remove).ConfigureAwait(false);
                 }
                 else
                 {
-                    _logger.Info("No Movie Deletes to Process");
+                    _logger.LogInformation("No Movie Deletes to Process");
                 }
 
                 var queuedMovieAdds = queue.Where(ev =>
@@ -121,12 +121,12 @@ namespace Trakt.Helpers
 
                 if (queuedMovieAdds.Any())
                 {
-                    _logger.Info(queuedMovieAdds.Count + " Movie Adds to Process");
+                    _logger.LogInformation(queuedMovieAdds.Count + " Movie Adds to Process");
                     await ProcessQueuedMovieEvents(queuedMovieAdds, traktUser, EventType.Add).ConfigureAwait(false);
                 }
                 else
                 {
-                    _logger.Info("No Movie Adds to Process");
+                    _logger.LogInformation("No Movie Adds to Process");
                 }
 
                 var queuedEpisodeDeletes = queue.Where(ev =>
@@ -136,12 +136,12 @@ namespace Trakt.Helpers
 
                 if (queuedEpisodeDeletes.Any())
                 {
-                    _logger.Info(queuedEpisodeDeletes.Count + " Episode Deletes to Process");
+                    _logger.LogInformation(queuedEpisodeDeletes.Count + " Episode Deletes to Process");
                     await ProcessQueuedEpisodeEvents(queuedEpisodeDeletes, traktUser, EventType.Remove).ConfigureAwait(false);
                 }
                 else
                 {
-                    _logger.Info("No Episode Deletes to Process");
+                    _logger.LogInformation("No Episode Deletes to Process");
                 }
 
                 var queuedEpisodeAdds = queue.Where(ev =>
@@ -151,12 +151,12 @@ namespace Trakt.Helpers
 
                 if (queuedEpisodeAdds.Any())
                 {
-                    _logger.Info(queuedEpisodeAdds.Count + " Episode Adds to Process");
+                    _logger.LogInformation(queuedEpisodeAdds.Count + " Episode Adds to Process");
                     await ProcessQueuedEpisodeEvents(queuedEpisodeAdds, traktUser, EventType.Add).ConfigureAwait(false);
                 }
                 else
                 {
-                    _logger.Info("No Episode Adds to Process");
+                    _logger.LogInformation("No Episode Adds to Process");
                 }
 
                 var queuedShowDeletes = queue.Where(ev =>
@@ -166,12 +166,12 @@ namespace Trakt.Helpers
 
                 if (queuedShowDeletes.Any())
                 {
-                    _logger.Info(queuedMovieDeletes.Count + " Series Deletes to Process");
+                    _logger.LogInformation(queuedMovieDeletes.Count + " Series Deletes to Process");
                     await ProcessQueuedShowEvents(queuedShowDeletes, traktUser, EventType.Remove).ConfigureAwait(false);
                 }
                 else
                 {
-                    _logger.Info("No Series Deletes to Process");
+                    _logger.LogInformation("No Series Deletes to Process");
                 }
             }
 
@@ -192,7 +192,7 @@ namespace Trakt.Helpers
             }
             catch (Exception ex)
             {
-                _logger.ErrorException("Exception handled processing queued series events", ex);
+                _logger.LogError("Exception handled processing queued series events", ex);
             }
         }
 
@@ -214,7 +214,7 @@ namespace Trakt.Helpers
             }
             catch (Exception ex)
             {
-                _logger.ErrorException("Exception handled processing queued movie events", ex);
+                _logger.LogError("Exception handled processing queued movie events", ex);
             }
 
         }
@@ -236,7 +236,7 @@ namespace Trakt.Helpers
             // Can't progress further without episodes
             if (!episodes.Any())
             {
-                _logger.Info("episodes count is 0");
+                _logger.LogInformation("episodes count is 0");
 
                 return;
             }
@@ -266,7 +266,7 @@ namespace Trakt.Helpers
                 }
                 catch (Exception ex)
                 {
-                    _logger.ErrorException("Exception handled processing queued episode events", ex);
+                    _logger.LogError("Exception handled processing queued episode events", ex);
                 }
             }
         }

--- a/Trakt/Helpers/UserDataManagerEventsHelper.cs
+++ b/Trakt/Helpers/UserDataManagerEventsHelper.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Logging;
+using Microsoft.Extensions.Logging;
 using MediaBrowser.Model.Threading;
 using Trakt.Api;
 using Trakt.Model;

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -16,7 +16,7 @@ namespace Trakt.ScheduledTasks
     using MediaBrowser.Controller.Library;
     using MediaBrowser.Model.Entities;
     using MediaBrowser.Model.IO;
-    using MediaBrowser.Model.Logging;
+    using Microsoft.Extensions.Logging;
     using MediaBrowser.Model.Serialization;
     using MediaBrowser.Model.Tasks;
 
@@ -45,7 +45,7 @@ namespace Trakt.ScheduledTasks
         private readonly ILibraryManager _libraryManager;
 
         public SyncLibraryTask(
-            ILogManager logger,
+            ILoggerFactory loggerFactory,
             IJsonSerializer jsonSerializer,
             IUserManager userManager,
             IUserDataManager userDataManager,
@@ -58,7 +58,7 @@ namespace Trakt.ScheduledTasks
             _userManager = userManager;
             _userDataManager = userDataManager;
             _libraryManager = libraryManager;
-            _logger = logger.GetLogger("Trakt");
+            _logger = loggerFactory.CreateLogger("Trakt");
             _traktApi = new TraktApi(jsonSerializer, _logger, httpClient, appHost, userDataManager, fileSystem);
         }
 
@@ -85,7 +85,7 @@ namespace Trakt.ScheduledTasks
             // No point going further if we don't have users.
             if (users.Count == 0)
             {
-                _logger.Info("No Users returned");
+                _logger.LogInformation("No Users returned");
                 return;
             }
 
@@ -96,7 +96,7 @@ namespace Trakt.ScheduledTasks
                 // I'll leave this in here for now, but in reality this continue should never be reached.
                 if (string.IsNullOrEmpty(traktUser?.LinkedMbUserId))
                 {
-                    _logger.Error("traktUser is either null or has no linked MB account");
+                    _logger.LogError("traktUser is either null or has no linked MB account");
                     continue;
                 }
 
@@ -225,7 +225,7 @@ namespace Trakt.ScheduledTasks
             ISplittableProgress<double> progress,
             CancellationToken cancellationToken)
         {
-            _logger.Info("Movies to " + (collected ? "add to" : "remove from") + " Collection: " + movies.Count);
+            _logger.LogInformation("Movies to " + (collected ? "add to" : "remove from") + " Collection: " + movies.Count);
             if (movies.Count > 0)
             {
                 try
@@ -247,11 +247,11 @@ namespace Trakt.ScheduledTasks
                 }
                 catch (ArgumentNullException argNullEx)
                 {
-                    _logger.ErrorException("ArgumentNullException handled sending movies to trakt.tv", argNullEx);
+                    _logger.LogError("ArgumentNullException handled sending movies to trakt.tv", argNullEx);
                 }
                 catch (Exception e)
                 {
-                    _logger.ErrorException("Exception handled sending movies to trakt.tv", e);
+                    _logger.LogError("Exception handled sending movies to trakt.tv", e);
                 }
 
                 progress.Report(100);
@@ -265,7 +265,7 @@ namespace Trakt.ScheduledTasks
             ISplittableProgress<double> progress,
             CancellationToken cancellationToken)
         {
-            _logger.Info("Movies to set " + (seen ? string.Empty : "un") + "watched: " + playedMovies.Count);
+            _logger.LogInformation("Movies to set " + (seen ? string.Empty : "un") + "watched: " + playedMovies.Count);
             if (playedMovies.Count > 0)
             {
                 try
@@ -282,7 +282,7 @@ namespace Trakt.ScheduledTasks
                 }
                 catch (Exception e)
                 {
-                    _logger.ErrorException("Error updating movie play states", e);
+                    _logger.LogError("Error updating movie play states", e);
                 }
 
                 progress.Report(100);
@@ -390,7 +390,7 @@ namespace Trakt.ScheduledTasks
             ISplittableProgress<double> progress,
             CancellationToken cancellationToken)
         {
-            _logger.Info("Episodes to set " + (seen ? string.Empty : "un") + "watched: " + playedEpisodes.Count);
+            _logger.LogInformation("Episodes to set " + (seen ? string.Empty : "un") + "watched: " + playedEpisodes.Count);
             if (playedEpisodes.Count > 0)
             {
                 try
@@ -407,7 +407,7 @@ namespace Trakt.ScheduledTasks
                 }
                 catch (Exception e)
                 {
-                    _logger.ErrorException("Error updating episode play states", e);
+                    _logger.LogError("Error updating episode play states", e);
                 }
 
                 progress.Report(100);
@@ -421,7 +421,7 @@ namespace Trakt.ScheduledTasks
             ISplittableProgress<double> progress,
             CancellationToken cancellationToken)
         {
-            _logger.Info("Episodes to add to Collection: " + collectedEpisodes.Count);
+            _logger.LogInformation("Episodes to add to Collection: " + collectedEpisodes.Count);
             if (collectedEpisodes.Count > 0)
             {
                 try
@@ -443,11 +443,11 @@ namespace Trakt.ScheduledTasks
                 }
                 catch (ArgumentNullException argNullEx)
                 {
-                    _logger.ErrorException("ArgumentNullException handled sending episodes to trakt.tv", argNullEx);
+                    _logger.LogError("ArgumentNullException handled sending episodes to trakt.tv", argNullEx);
                 }
                 catch (Exception e)
                 {
-                    _logger.ErrorException("Exception handled sending episodes to trakt.tv", e);
+                    _logger.LogError("Exception handled sending episodes to trakt.tv", e);
                 }
 
                 progress.Report(100);
@@ -463,28 +463,28 @@ namespace Trakt.ScheduledTasks
 
         private void LogTraktResponseDataContract(TraktSyncResponse dataContract)
         {
-            _logger.Debug("TraktResponse Added Movies: " + dataContract.added.movies);
-            _logger.Debug("TraktResponse Added Shows: " + dataContract.added.shows);
-            _logger.Debug("TraktResponse Added Seasons: " + dataContract.added.seasons);
-            _logger.Debug("TraktResponse Added Episodes: " + dataContract.added.episodes);
+            _logger.LogDebug("TraktResponse Added Movies: " + dataContract.added.movies);
+            _logger.LogDebug("TraktResponse Added Shows: " + dataContract.added.shows);
+            _logger.LogDebug("TraktResponse Added Seasons: " + dataContract.added.seasons);
+            _logger.LogDebug("TraktResponse Added Episodes: " + dataContract.added.episodes);
             foreach (var traktMovie in dataContract.not_found.movies)
             {
-                _logger.Error("TraktResponse not Found:" + _jsonSerializer.SerializeToString(traktMovie));
+                _logger.LogError("TraktResponse not Found:" + _jsonSerializer.SerializeToString(traktMovie));
             }
 
             foreach (var traktShow in dataContract.not_found.shows)
             {
-                _logger.Error("TraktResponse not Found:" + _jsonSerializer.SerializeToString(traktShow));
+                _logger.LogError("TraktResponse not Found:" + _jsonSerializer.SerializeToString(traktShow));
             }
 
             foreach (var traktSeason in dataContract.not_found.seasons)
             {
-                _logger.Error("TraktResponse not Found:" + _jsonSerializer.SerializeToString(traktSeason));
+                _logger.LogError("TraktResponse not Found:" + _jsonSerializer.SerializeToString(traktSeason));
             }
 
             foreach (var traktEpisode in dataContract.not_found.episodes)
             {
-                _logger.Error("TraktResponse not Found:" + _jsonSerializer.SerializeToString(traktEpisode));
+                _logger.LogError("TraktResponse not Found:" + _jsonSerializer.SerializeToString(traktEpisode));
             }
         }
     }

--- a/Trakt/Trakt.csproj
+++ b/Trakt/Trakt.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="mediabrowser.server.core" Version="3.6.0.68-beta" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I was able to get this plugin to build and load under the latest Ubuntu release of the Jellyfin server.  I also copied `plugins/configurations/Trakt.xml` from my Emby  data dir.  It still can't talk to the Trakt API:

```
[2019-01-21 12:12:53.709 -08:00] [INF] Executing "Import playstates from Trakt.tv"
[2019-01-21 12:12:53.715 -08:00] [ERR] Error
System.MissingMethodException: Method not found: 'MediaBrowser.Controller.Entities.User[] MediaBrowser.Controller.Library.IUserManager.get_Users()'.
   at Trakt.ScheduledTasks.SyncFromTraktTask.Execute(CancellationToken cancellationToken, IProgress`1 progress)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Trakt.ScheduledTasks.SyncFromTraktTask.Execute(CancellationToken cancellationToken, IProgress`1 progress)
   at Emby.Server.Implementations.ScheduledTasks.ScheduledTaskWorker.ExecuteInternal(TaskOptions options)
[2019-01-21 12:12:53.718 -08:00] [INF] "Import playstates from Trakt.tv" Failed after 0 minute(s) and 0 seconds
```

But I thought I'd submit a PR anyways in case it gets things moving.

Thanks for the fork!