### PR TITLE
Update version and Jellyfin version to 10.*

### DIFF
--- a/Trakt/Trakt.csproj
+++ b/Trakt/Trakt.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <FileVersion>2.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Trakt/Trakt.csproj
+++ b/Trakt/Trakt.csproj
@@ -2,10 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.2.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.*" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,10 @@
 ---
 name: "jellyfin-plugin-trakt"
 guid: "4fe3201e-d6ae-4f2e-8917-e12bda571281"
-version: "1.0.0"
+version: "2" # Please increment with each pull request
+jellyfin_version: "10.3.0" # The earliest binary-compatible version
 nicename: "Trakt"
+owner: "jellyfin"
 description: "Record your watched media with Trakt"
 overview: >
   Record your watched media with Trakt.


### PR DESCRIPTION
Alternative to #10, just use a wildcard which matches the general major version and whatever the latest subversion is. This *seems* to work but needs testing.

Also remove the AssemblyVersion and FileVersion - these don't actually seem to be needed for anything useful - just more things to increment. The LDAP plugin proves they're not required.