### PR TITLE
Update README to include Jellyfin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-## Trakt for Emby
+## Trakt for Jellyfin
 
-How to test. You'll need to create a Trakt application. Once you've done that, the client id and secret in the source code need to be replaced with valid values. See TraktURIs.cs and configPage.html and replace the client id and secret.
+Available for install through your Jellyfin plugin page, Trakt for Jellyfin allows you to synchronize your user's watched states with ease.


### PR DESCRIPTION
Puts our project's name in the README, and removes the unneeded instructions.