### PR TITLE
Update the version to 3.0.0

### DIFF
--- a/Trakt/Trakt.csproj
+++ b/Trakt/Trakt.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
-    <FileVersion>2.0.0</FileVersion>
+    <AssemblyVersion>3.0.0</AssemblyVersion>
+    <FileVersion>3.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates the version inside the DLL to match the manifest reported version. Without this, installing the 3.0.0 plugin will read as 2.0.0 on the Dashboard.