### PR TITLE
New Sync Options (collections and scrobbling)

### DIFF
--- a/Trakt/Configuration/configPage.html
+++ b/Trakt/Configuration/configPage.html
@@ -70,6 +70,24 @@
                             Send audio and video metadata to Trakt.
                         </div>
                     </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkSyncCollections" name="chkSyncCollections" />
+                            <span>Synchronize Collection</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">
+                            Synchronize the collected movies and shows to Trakt.
+                        </div>
+                    </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkScrobble" name="chkScrobble" />
+                            <span>Scrobble</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">
+                            Scrobble to Trakt.
+                        </div>
+                    </div>
                     <div>
                         <button is="emby-button" type="submit" class="raised button-submit block"><span>${ButtonSave}</span></button>
                     </div>
@@ -122,7 +140,9 @@
                                     SkipUnwatchedImportFromTrakt: true,
                                     PostWatchedHistory: true,
                                     ExtraLogging: false,
-                                    ExportMediaInfo: false
+                                    ExportMediaInfo: false,
+                                    SynchronizeCollections: true,
+                                    Scrobble: true
                                 };
                             }
                             // Default this to an empty array so the rendering code doesn't have to worry about it
@@ -131,6 +151,8 @@
                             $('#chkPostWatchedHistory', page).checked(currentUserConfig.PostWatchedHistory).checkboxradio("refresh");
                             $('#chkExtraLogging', page).checked(currentUserConfig.ExtraLogging).checkboxradio("refresh");
                             $('#chkExportMediaInfo', page).checked(currentUserConfig.ExportMediaInfo).checkboxradio("refresh");
+                            $('#chkSyncCollections', page).checked(currentUserConfig.SynchronizeCollections).checkboxradio("refresh");
+                            $('#chkScrobble', page).checked(currentUserConfig.Scrobble).checkboxradio("refresh");
                             // List the folders the user can access
                             ApiClient.getVirtualFolders(userId).then(function (result) {
                                 TraktConfigurationPage.loadFolders(currentUserConfig, result);
@@ -191,6 +213,8 @@
                     currentUserConfig.PostWatchedHistory = $('#chkPostWatchedHistory', page).checked();
                     currentUserConfig.ExtraLogging = $('#chkExtraLogging', page).checked();
                     currentUserConfig.ExportMediaInfo = $('#chkExportMediaInfo', page).checked();
+                    currentUserConfig.SynchronizeCollections = $('#chkSyncCollections', page).checked();
+                    currentUserConfig.Scrobble = $('#chkScrobble', page).checked();
                     currentUserConfig.LinkedMbUserId = currentUserId;
                     currentUserConfig.LocationsExcluded = $('.chkTraktLocation:checked', page).map(function () {
                         return this.getAttribute('data-location');

--- a/Trakt/Model/TraktUser.cs
+++ b/Trakt/Model/TraktUser.cs
@@ -13,13 +13,17 @@ namespace Trakt.Model
 
         public bool UsesAdvancedRating { get; set; }
 
-        public bool  SkipUnwatchedImportFromTrakt { get; set; }
+        public bool SkipUnwatchedImportFromTrakt { get; set; }
 
         public bool PostWatchedHistory { get; set; }
 
         public bool ExtraLogging { get; set; }
 
         public bool ExportMediaInfo { get; set; }
+
+        public bool SynchronizeCollections { get; set; }
+
+        public bool Scrobble { get; set; }
 
         public String[] LocationsExcluded { get; set; }
         public DateTime AccessTokenExpiration { get; set; }
@@ -30,6 +34,8 @@ namespace Trakt.Model
             PostWatchedHistory = true;
             ExtraLogging = false;
             ExportMediaInfo = false;
+            SynchronizeCollections = true;
+            Scrobble = true;
         }
     }
 }

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -158,7 +158,7 @@ namespace Trakt.ScheduledTasks
                 var libraryMovie = child as Movie;
                 var userData = _userDataManager.GetUserData(user.Id, child);
 
-                if(traktUser.SynchronizeCollections)
+                if (traktUser.SynchronizeCollections)
                 {
                     // if movie is not collected, or (export media info setting is enabled and every collected matching movie has different metadata), collect it
                     var collectedMathingMovies = SyncFromTraktTask.FindMatches(libraryMovie, traktCollectedMovies).ToList();

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -385,7 +385,9 @@ namespace Trakt.ScheduledTasks
             }
 
             if (traktUser.SynchronizeCollections)
+            {
                 await SendEpisodeCollectionUpdates(true, traktUser, collectedEpisodes, progress.Split(4), cancellationToken).ConfigureAwait(false);
+            }
 
             await SendEpisodePlaystateUpdates(true, traktUser, playedEpisodes, progress.Split(4), cancellationToken).ConfigureAwait(false);
 

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -212,7 +212,9 @@ namespace Trakt.ScheduledTasks
 
             // send movies to mark collected
             if (traktUser.SynchronizeCollections)
+            {
                 await SendMovieCollectionUpdates(true, traktUser, collectedMovies, progress.Split(4), cancellationToken).ConfigureAwait(false);
+            }
 
             // send movies to mark watched
             await SendMoviePlaystateUpdates(true, traktUser, playedMovies, progress.Split(4), cancellationToken).ConfigureAwait(false);

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -211,7 +211,7 @@ namespace Trakt.ScheduledTasks
             }
 
             // send movies to mark collected
-            if(traktUser.SynchronizeCollections)
+            if (traktUser.SynchronizeCollections)
                 await SendMovieCollectionUpdates(true, traktUser, collectedMovies, progress.Split(4), cancellationToken).ConfigureAwait(false);
 
             // send movies to mark watched

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -208,7 +208,8 @@ namespace Trakt.ScheduledTasks
             }
 
             // send movies to mark collected
-            await SendMovieCollectionUpdates(true, traktUser, collectedMovies, progress.Split(4), cancellationToken).ConfigureAwait(false);
+            if(traktUser.SynchronizeCollections)
+                await SendMovieCollectionUpdates(true, traktUser, collectedMovies, progress.Split(4), cancellationToken).ConfigureAwait(false);
 
             // send movies to mark watched
             await SendMoviePlaystateUpdates(true, traktUser, playedMovies, progress.Split(4), cancellationToken).ConfigureAwait(false);
@@ -375,7 +376,8 @@ namespace Trakt.ScheduledTasks
                 decisionProgress.Report(100);
             }
 
-            await SendEpisodeCollectionUpdates(true, traktUser, collectedEpisodes, progress.Split(4), cancellationToken).ConfigureAwait(false);
+            if(traktUser.SynchronizeCollections)
+                await SendEpisodeCollectionUpdates(true, traktUser, collectedEpisodes, progress.Split(4), cancellationToken).ConfigureAwait(false);
 
             await SendEpisodePlaystateUpdates(true, traktUser, playedEpisodes, progress.Split(4), cancellationToken).ConfigureAwait(false);
 

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -384,7 +384,7 @@ namespace Trakt.ScheduledTasks
                 decisionProgress.Report(100);
             }
 
-            if(traktUser.SynchronizeCollections)
+            if (traktUser.SynchronizeCollections)
                 await SendEpisodeCollectionUpdates(true, traktUser, collectedEpisodes, progress.Split(4), cancellationToken).ConfigureAwait(false);
 
             await SendEpisodePlaystateUpdates(true, traktUser, playedEpisodes, progress.Split(4), cancellationToken).ConfigureAwait(false);

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -369,7 +369,7 @@ namespace Trakt.ScheduledTasks
                     unplayedEpisodes.Add(episode);
                 }
 
-                if(traktUser.SynchronizeCollections)
+                if (traktUser.SynchronizeCollections)
                 {
                     var traktCollectedShow = SyncFromTraktTask.FindMatch(episode.Series, traktCollectedShows);
                     if (traktCollectedShow?.seasons == null

--- a/Trakt/ServerMediator.cs
+++ b/Trakt/ServerMediator.cs
@@ -239,7 +239,9 @@ namespace Trakt
                 }
                 
                 if (!traktUser.Scrobble)
+                {
                     return;
+                }
 
                 if (!_traktApi.CanSync(e.Item, traktUser))
                 {

--- a/Trakt/ServerMediator.cs
+++ b/Trakt/ServerMediator.cs
@@ -161,6 +161,9 @@ namespace Trakt
                     _logger.LogInformation("Could not match user with any stored credentials");
                     return;
                 }
+                
+                if (!traktUser.Scrobble)
+                    return;
 
                 if (!_traktApi.CanSync(e.Item, traktUser))
                 {
@@ -232,6 +235,9 @@ namespace Trakt
                     _logger.LogError("Could not match trakt user");
                     return;
                 }
+                
+                if (!traktUser.Scrobble)
+                    return;
 
                 if (!_traktApi.CanSync(e.Item, traktUser))
                 {

--- a/Trakt/ServerMediator.cs
+++ b/Trakt/ServerMediator.cs
@@ -163,7 +163,9 @@ namespace Trakt
                 }
                 
                 if (!traktUser.Scrobble)
+                {
                     return;
+                }
 
                 if (!_traktApi.CanSync(e.Item, traktUser))
                 {


### PR DESCRIPTION
I added options to disable collection synchronization to Trakt as well as scrobbling. 
The main change was adding the two UI elements. The default values for both options are enabled so that the behavior is as it was before.

Other Information
- This is not the most efficient way to implement this as some work performed in SyncMovies and SyncShows is now useless.
- I could only test that it is working for my own account.