### PR TITLE
Add more fine-grained settings to control Trakt syncing

### DIFF
--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -734,7 +734,7 @@ namespace Trakt.Api
         /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns></returns>
         // TODO: netstandard2.1: use IAsyncEnumerable
-        public async Task<List<TraktSyncResponse>> SendMoviePlaystateUpdates(List<Movie> movies, TraktUser traktUser, bool forceUpdate, bool seen, CancellationToken cancellationToken)
+        public async Task<List<TraktSyncResponse>> SendMoviePlaystateUpdates(List<Movie> movies, TraktUser traktUser, bool seen, CancellationToken cancellationToken)
         {
             if (movies == null)
             {
@@ -744,11 +744,6 @@ namespace Trakt.Api
             if (traktUser == null)
             {
                 throw new ArgumentNullException(nameof(traktUser));
-            }
-
-            if (!forceUpdate && !traktUser.PostWatchedHistory)
-            {
-                return new List<TraktSyncResponse>();
             }
 
             var moviesPayload = movies.Select(m =>
@@ -802,7 +797,7 @@ namespace Trakt.Api
         /// <param name="seen">True if episodes are being marked seen, false otherwise</param>
         /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns></returns>
-        public async Task<List<TraktSyncResponse>> SendEpisodePlaystateUpdates(List<Episode> episodes, TraktUser traktUser, bool forceUpdate, bool seen, CancellationToken cancellationToken)
+        public async Task<List<TraktSyncResponse>> SendEpisodePlaystateUpdates(List<Episode> episodes, TraktUser traktUser, bool seen, CancellationToken cancellationToken)
         {
             if (episodes == null)
             {
@@ -812,11 +807,6 @@ namespace Trakt.Api
             if (traktUser == null)
             {
                 throw new ArgumentNullException(nameof(traktUser));
-            }
-
-            if (!forceUpdate && !traktUser.PostWatchedHistory)
-            {
-                return new List<TraktSyncResponse>();
             }
 
             var chunks = episodes.ToChunks(100).ToList();

--- a/Trakt/Configuration/configPage.html
+++ b/Trakt/Configuration/configPage.html
@@ -24,7 +24,7 @@
                         </div>
                         <button is="emby-button" type="button" id="authorizeDevice" class="raised block">Authorize device</button>
                         <div id="activateWithCode" class="hide">
-                            Please visit <a href="https://trakt.tv/activate"  class="button-link emby-button"target="_blank">https://trakt.tv/activate</a> and authorize Jellyfin to access your account.<br/>
+                            Please visit <a href="https://trakt.tv/activate" class="button-link emby-button" target="_blank">https://trakt.tv/activate</a> and authorize Jellyfin to access your account.<br />
                             Your device code is <span id="userCode"></span>.
                         </div>
                     </div>
@@ -40,16 +40,52 @@
                             <span>Skip unwatched import from Trakt</span>
                         </label>
                         <div class="fieldDescription checkboxFieldDescription">
-                            The Import from Trakt scheduled task will overwrite any watched status if item is marked as unwached on Trakt. If checked, only watched status will be imported.
+                            The Import from Trakt scheduled task will set local items unwatched if item is marked as unwached on Trakt. If checked, do not import unwatched status.
+                        </div>
+                    </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkSkipWatchedImportFromTrakt" name="chkSkipWatchedImportFromTrakt" />
+                            <span>Skip watched import from Trakt</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">
+                            The Import from Trakt scheduled task will set local items as watched if item is marked as watched on Trakt. If checked, do not import watched status.
                         </div>
                     </div>
                     <div class="checkboxContainer checkboxContainer-withDescription">
                         <label>
                             <input is="emby-checkbox" type="checkbox" id="chkPostWatchedHistory" name="chkPostWatchedHistory" />
-                            <span>Update Trakt watched history during Scheduled Task</span>
+                            <span>During Scheduled Task, set Trakt items to watched if local item is watched</span>
                         </label>
                         <div class="fieldDescription checkboxFieldDescription">
-                            If checked, Jellyfin will only sync from Trakt during the Trakt scheduled tasks.
+                            Controls what is synced to Trakt when when scheduled task is run.
+                        </div>
+                    </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkPostUnwatchedHistory" name="chkPostUnwatchedHistory" />
+                            <span>During Scheduled Task, set Trakt items to unwatched if local item is unwatched</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">
+                            Controls what is synced to Trakt when when scheduled task is run.
+                        </div>
+                    </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkPostSetWatched" name="chkPostSetWatched" />
+                            <span>Set Trakt item to Watched when local item is changed to Watched.</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">
+                            Controls what is synced to Trakt when item statuses are changed during normal use.
+                        </div>
+                    </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkPostSetUnwatched" name="chkPostSetUnwatched" />
+                            <span>Set Trakt item to Unwatched when local item is changed to Unwatched.</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">
+                            Controls what is synced to Trakt when item statuses are changed during normal use.
                         </div>
                     </div>
                     <div class="checkboxContainer checkboxContainer-withDescription">
@@ -137,7 +173,11 @@
                                 currentUserConfig = {
                                     AccessToken: null,
                                     SkipUnwatchedImportFromTrakt: true,
+                                    SkipWatchedImportFromTrakt: false,
                                     PostWatchedHistory: true,
+                                    PostUnwatchedHistory: true,
+                                    PostSetWatched: true,
+                                    PostSetUnwatched: true,
                                     ExtraLogging: false,
                                     ExportMediaInfo: false,
                                     SynchronizeCollections: true,
@@ -147,7 +187,11 @@
                             // Default this to an empty array so the rendering code doesn't have to worry about it
                             currentUserConfig.LocationsExcluded = currentUserConfig.LocationsExcluded || [];
                             $('#chkSkipUnwatchedImportFromTrakt', page).checked(currentUserConfig.SkipUnwatchedImportFromTrakt).checkboxradio("refresh");
+                            $('#chkSkipWatchedImportFromTrakt', page).checked(currentUserConfig.SkipWatchedImportFromTrakt).checkboxradio("refresh");
                             $('#chkPostWatchedHistory', page).checked(currentUserConfig.PostWatchedHistory).checkboxradio("refresh");
+                            $('#chkPostUnwatchedHistory', page).checked(currentUserConfig.PostUnwatchedHistory).checkboxradio("refresh");
+                            $('#chkPostSetWatched', page).checked(currentUserConfig.PostSetWatched).checkboxradio("refresh");
+                            $('#chkPostSetUnwatched', page).checked(currentUserConfig.PostSetUnwatched).checkboxradio("refresh");
                             $('#chkExtraLogging', page).checked(currentUserConfig.ExtraLogging).checkboxradio("refresh");
                             $('#chkExportMediaInfo', page).checked(currentUserConfig.ExportMediaInfo).checkboxradio("refresh");
                             $('#chkSyncCollections', page).checked(currentUserConfig.SynchronizeCollections).checkboxradio("refresh");
@@ -208,7 +252,11 @@
                         config.TraktUsers.push(currentUserConfig);
                     }
                     currentUserConfig.SkipUnwatchedImportFromTrakt = $('#chkSkipUnwatchedImportFromTrakt', page).checked();
+                    currentUserConfig.SkipWatchedImportFromTrakt = $('#chkSkipWatchedImportFromTrakt', page).checked();
                     currentUserConfig.PostWatchedHistory = $('#chkPostWatchedHistory', page).checked();
+                    currentUserConfig.PostUnwatchedHistory = $('#chkPostUnwatchedHistory', page).checked();
+                    currentUserConfig.PostSetWatched = $('#chkPostSetWatched', page).checked();
+                    currentUserConfig.PostSetUnwatched = $('#chkPostSetUnwatched', page).checked();
                     currentUserConfig.ExtraLogging = $('#chkExtraLogging', page).checked();
                     currentUserConfig.ExportMediaInfo = $('#chkExportMediaInfo', page).checked();
                     currentUserConfig.SynchronizeCollections = $('#chkSyncCollections', page).checked();

--- a/Trakt/Helpers/UserDataManagerEventsHelper.cs
+++ b/Trakt/Helpers/UserDataManagerEventsHelper.cs
@@ -67,7 +67,10 @@ namespace Trakt.Helpers
             {
                 if (userDataSaveEventArgs.UserData.Played)
                 {
-                    userPackage.SeenMovies.Add(movie);
+                    if(traktUser.PostSetWatched)
+                    {
+                        userPackage.SeenMovies.Add(movie);
+                    }
 
                     if (userPackage.SeenMovies.Count >= 100)
                     {
@@ -75,21 +78,22 @@ namespace Trakt.Helpers
                             userPackage.SeenMovies,
                             userPackage.TraktUser,
                             true,
-                            true,
                             CancellationToken.None).ConfigureAwait(false);
                         userPackage.SeenMovies = new List<Movie>();
                     }
                 }
                 else
                 {
-                    userPackage.UnSeenMovies.Add(movie);
+                    if(traktUser.PostSetUnwatched)
+                    {
+                        userPackage.UnSeenMovies.Add(movie);
+                    }
 
                     if (userPackage.UnSeenMovies.Count >= 100)
                     {
                         _traktApi.SendMoviePlaystateUpdates(
                             userPackage.UnSeenMovies,
                             userPackage.TraktUser,
-                            true,
                             false,
                             CancellationToken.None).ConfigureAwait(false);
                         userPackage.UnSeenMovies = new List<Movie>();
@@ -114,7 +118,6 @@ namespace Trakt.Helpers
                         userPackage.SeenEpisodes,
                         userPackage.TraktUser,
                         true,
-                        true,
                         CancellationToken.None).ConfigureAwait(false);
                     userPackage.SeenEpisodes = new List<Episode>();
                 }
@@ -124,7 +127,6 @@ namespace Trakt.Helpers
                     _traktApi.SendEpisodePlaystateUpdates(
                         userPackage.UnSeenEpisodes,
                         userPackage.TraktUser,
-                        true,
                         false,
                         CancellationToken.None).ConfigureAwait(false);
                     userPackage.UnSeenEpisodes = new List<Episode>();
@@ -135,11 +137,17 @@ namespace Trakt.Helpers
 
             if (userDataSaveEventArgs.UserData.Played)
             {
-                userPackage.SeenEpisodes.Add(episode);
+                if (traktUser.PostSetWatched)
+                {
+                    userPackage.SeenEpisodes.Add(episode);
+                }
             }
             else
             {
-                userPackage.UnSeenEpisodes.Add(episode);
+                if(traktUser.PostSetUnwatched)
+                {
+                    userPackage.UnSeenEpisodes.Add(episode);
+                }
             }
         }
 
@@ -154,7 +162,6 @@ namespace Trakt.Helpers
                     _traktApi.SendMoviePlaystateUpdates(
                         movies,
                         package.TraktUser,
-                        true,
                         false,
                         CancellationToken.None).ConfigureAwait(false);
                 }
@@ -167,7 +174,6 @@ namespace Trakt.Helpers
                         movies,
                         package.TraktUser,
                         true,
-                        true,
                         CancellationToken.None).ConfigureAwait(false);
                 }
                 if (package.UnSeenEpisodes.Any())
@@ -177,7 +183,6 @@ namespace Trakt.Helpers
                     _traktApi.SendEpisodePlaystateUpdates(
                         episodes,
                         package.TraktUser,
-                        true,
                         false,
                         CancellationToken.None).ConfigureAwait(false);
                 }
@@ -188,7 +193,6 @@ namespace Trakt.Helpers
                     _traktApi.SendEpisodePlaystateUpdates(
                         episodes,
                         package.TraktUser,
-                        true,
                         true,
                         CancellationToken.None).ConfigureAwait(false);
                 }

--- a/Trakt/Model/TraktUser.cs
+++ b/Trakt/Model/TraktUser.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace Trakt.Model
 {
@@ -15,7 +14,15 @@ namespace Trakt.Model
 
         public bool SkipUnwatchedImportFromTrakt { get; set; }
 
+        public bool SkipWatchedImportFromTrakt { get; set; }
+
         public bool PostWatchedHistory { get; set; }
+
+        public bool PostUnwatchedHistory { get; set; }
+
+        public bool PostSetWatched { get; set; }
+
+        public bool PostSetUnwatched { get; set; }
 
         public bool ExtraLogging { get; set; }
 
@@ -25,14 +32,18 @@ namespace Trakt.Model
 
         public bool Scrobble { get; set; }
 
-        public IReadOnlyList<string> LocationsExcluded { get; set; }
+        public string[] LocationsExcluded { get; set; }
 
         public DateTime AccessTokenExpiration { get; set; }
 
         public TraktUser()
         {
             SkipUnwatchedImportFromTrakt = true;
+            SkipWatchedImportFromTrakt = false;
             PostWatchedHistory = true;
+            PostUnwatchedHistory = true;
+            PostSetWatched = true;
+            PostSetUnwatched = true;
             ExtraLogging = false;
             ExportMediaInfo = false;
             SynchronizeCollections = true;

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -237,23 +237,26 @@ namespace Trakt.ScheduledTasks
                         {
                             _logger.LogDebug("Episode is in Watched list " + GetVerboseEpisodeData(episode));
 
-                            // Set episode as watched
-                            if (!userData.Played)
+                            if(!traktUser.SkipWatchedImportFromTrakt)
                             {
-                                userData.Played = true;
-                                userData.LastPlayedDate = DateTimeOffset.UtcNow.UtcDateTime;
-                                changed = true;
-                            }
+                                // Set episode as watched
+                                if (!userData.Played)
+                                {
+                                    userData.Played = true;
+                                    userData.LastPlayedDate = DateTimeOffset.UtcNow.UtcDateTime;
+                                    changed = true;
+                                }
 
-                            // keep the highest play count
-                            int playcount = Math.Max(matchedEpisode.plays, userData.PlayCount);
+                                // keep the highest play count
+                                int playcount = Math.Max(matchedEpisode.plays, userData.PlayCount);
 
-                            // set episode playcount
-                            if (userData.PlayCount != playcount)
-                            {
-                                userData.PlayCount = playcount;
-                                changed = true;
-                            }
+                                // set episode playcount
+                                if (userData.PlayCount != playcount)
+                                {
+                                    userData.PlayCount = playcount;
+                                    changed = true;
+                                }
+                            }                         
                         }
                         else if (!traktUser.SkipUnwatchedImportFromTrakt)
                         {

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -197,7 +197,7 @@ namespace Trakt.ScheduledTasks
                 else
                 {
                     // If the show has not been played locally but is played on trakt.tv then add it to the unplayed list
-                    if (movieWatched != null)
+                    if (movieWatched != null && traktUser.PostUnwatchedHistory)
                     {
                         unplayedMovies.Add(libraryMovie);
                     }
@@ -272,7 +272,7 @@ namespace Trakt.ScheduledTasks
                 try
                 {
                     var dataContracts =
-                        await _traktApi.SendMoviePlaystateUpdates(playedMovies, traktUser, false, seen, cancellationToken).ConfigureAwait(false);
+                        await _traktApi.SendMoviePlaystateUpdates(playedMovies, traktUser, seen, cancellationToken).ConfigureAwait(false);
                     if (dataContracts != null)
                     {
                         foreach (var traktSyncResponse in dataContracts)
@@ -359,7 +359,7 @@ namespace Trakt.ScheduledTasks
                         }
                     }
                 }
-                else if (userData != null && !userData.Played && isPlayedTraktTv)
+                else if (userData != null && !userData.Played && isPlayedTraktTv && traktUser.PostUnwatchedHistory)
                 {
                     // If the show has not been played locally but is played on trakt.tv then add it to the unplayed list
                     unplayedEpisodes.Add(episode);
@@ -403,7 +403,7 @@ namespace Trakt.ScheduledTasks
                 try
                 {
                     var dataContracts =
-                        await _traktApi.SendEpisodePlaystateUpdates(playedEpisodes, traktUser, false, seen, cancellationToken).ConfigureAwait(false);
+                        await _traktApi.SendEpisodePlaystateUpdates(playedEpisodes, traktUser, seen, cancellationToken).ConfigureAwait(false);
                     if (dataContracts != null)
                     {
                         foreach (var con in dataContracts)

--- a/Trakt/ServerMediator.cs
+++ b/Trakt/ServerMediator.cs
@@ -87,7 +87,13 @@ namespace Trakt
                     return;
                 }
 
-                // We have a user and the item is in a trakt monitored location.
+                if (!traktUser.PostSetWatched && !traktUser.PostSetUnwatched)
+                {
+                    // User doesn't want to post any status changes at all.
+                    return;
+                }
+
+                // We have a user who wants to post updates and the item is in a trakt monitored location.
                 _userDataManagerEventsHelper.ProcessUserDataSaveEventArgs(e, traktUser);
             }
         }

--- a/Trakt/Trakt.csproj
+++ b/Trakt/Trakt.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <AssemblyVersion>8.0.0</AssemblyVersion>
-    <FileVersion>8.0.0</FileVersion>
+    <AssemblyVersion>9.0.0</AssemblyVersion>
+    <FileVersion>9.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "jellyfin-plugin-trakt"
 guid: "4fe3201e-d6ae-4f2e-8917-e12bda571281"
-version: "8"
+version: "9"
 jellyfin_version: "10.5.0"
 nicename: "Trakt"
 owner: "jellyfin"


### PR DESCRIPTION
The purpose of this is for the use case described here:
https://www.reddit.com/r/jellyfin/comments/ff5f9u/sharing_watched_status_between_users/


> The idea is to have separate Jellyfin accounts each for tracking personal watched status, and also some kind of shared view/account which essentially shows the union of all our watched statuses - so that when we're watching together we can pick something none of us have watched yet. Furthermore watching something from the common view should mark it watched in each of the separate accounts.


Currently the Trakt plugin only supports essentially bi-directional sync for every user, making it unsuitable for the above use case.
The changes in this request are not specifically bound to that use case, they just add enough control over the Trakt syncing to enable this use case and maybe more.
The key part which enables the use case is allowing some users to be uni-directionally syncing their watches up to Trakt, while a common/master account syncs bi-directionally with the same Trakt account.

I have tested this on Jellyfin 10.4.3 with success.



The behavior of the plugin with default settings is unchanged.
Could particularly do with review of the wording on the plugin settings html page.




There is one change which is not related to the title of this request, but seemed to be a bug - at least when running with Jellyfin 10.4.3:
When TraktUser.LocationsExcluded was declared as a IReadOnlyList<string>, it caused the below exception. Rolling back the change made in #28 so that it is a string[] again fixed the issue. If that was a change intended for Jellyfin 10.5 support then I'd be happy to remove my change to that line.

```
[2020-03-08 05:41:12.085 +00:00] [ERR] Error processing request
System.InvalidOperationException: There was an error reflecting type 'Trakt.Configuration.PluginConfiguration'. ---> System.InvalidOperationException: There was an error reflecting property 'TraktUsers'. ---> System.InvalidOperationException: There was an error reflecting type 'Trakt.Model.TraktUser'. ---> System.InvalidOperationException: Cannot serialize member 'Trakt.Model.TraktUser.LocationsExcluded' of type 'System.Collections.Generic.IReadOnlyList1[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]', see inner exception for more details. ---> System.NotSupportedException: Cannot serialize member Trakt.Model.TraktUser.LocationsExcluded of type System.Collections.Generic.IReadOnlyList1[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]] because it is an interface.
   --- End of inner exception stack trace ---
   at System.Xml.Serialization.StructModel.CheckSupportedMember(TypeDesc typeDesc, MemberInfo member, Type type)
   at System.Xml.Serialization.StructModel.GetPropertyModel(PropertyInfo propertyInfo)
   at System.Xml.Serialization.StructModel.GetFieldModel(MemberInfo memberInfo)
   at System.Xml.Serialization.XmlReflectionImporter.InitializeStructMembers(StructMapping mapping, StructModel model, Boolean openModel, String typeName, RecursionLimiter limiter)
   at System.Xml.Serialization.XmlReflectionImporter.ImportStructLikeMapping(StructModel model, String ns, Boolean openModel, XmlAttributes a, RecursionLimiter limiter)
   at System.Xml.Serialization.XmlReflectionImporter.ImportTypeMapping(TypeModel model, String ns, ImportContext context, String dataType, XmlAttributes a, Boolean repeats, Boolean openModel, RecursionLimiter limiter)
   --- End of inner exception stack trace ---
   at System.Xml.Serialization.XmlReflectionImporter.ImportTypeMapping(TypeModel model, String ns, ImportContext context, String dataType, XmlAttributes a, Boolean repeats, Boolean openModel, RecursionLimiter limiter)
   at System.Xml.Serialization.XmlReflectionImporter.CreateArrayElementsFromAttributes(ArrayMapping arrayMapping, XmlArrayItemAttributes attributes, Type arrayElementType, String arrayElementNs, RecursionLimiter limiter)
   at System.Xml.Serialization.XmlReflectionImporter.ImportArrayLikeMapping(ArrayModel model, String ns, RecursionLimiter limiter)
   at System.Xml.Serialization.XmlReflectionImporter.ImportAccessorMapping(MemberMapping accessor, FieldModel model, XmlAttributes a, String ns, Type choiceIdentifierType, Boolean rpc, Boolean openModel, RecursionLimiter limiter)
   at System.Xml.Serialization.XmlReflectionImporter.ImportFieldMapping(StructModel parent, FieldModel model, XmlAttributes a, String ns, RecursionLimiter limiter)
   at System.Xml.Serialization.XmlReflectionImporter.InitializeStructMembers(StructMapping mapping, StructModel model, Boolean openModel, String typeName, RecursionLimiter limiter)
   --- End of inner exception stack trace ---
   at System.Xml.Serialization.XmlReflectionImporter.InitializeStructMembers(StructMapping mapping, StructModel model, Boolean openModel, String typeName, RecursionLimiter limiter)
   at System.Xml.Serialization.XmlReflectionImporter.ImportStructLikeMapping(StructModel model, String ns, Boolean openModel, XmlAttributes a, RecursionLimiter limiter)
   at System.Xml.Serialization.XmlReflectionImporter.ImportTypeMapping(TypeModel model, String ns, ImportContext context, String dataType, XmlAttributes a, Boolean repeats, Boolean openModel, RecursionLimiter limiter)
   --- End of inner exception stack trace ---
   at System.Xml.Serialization.XmlReflectionImporter.ImportTypeMapping(TypeModel model, String ns, ImportContext context, String dataType, XmlAttributes a, Boolean repeats, Boolean openModel, RecursionLimiter limiter)
   at System.Xml.Serialization.XmlReflectionImporter.ImportElement(TypeModel model, XmlRootAttribute root, String defaultNamespace, RecursionLimiter limiter)
   at System.Xml.Serialization.XmlReflectionImporter.ImportTypeMapping(Type type, XmlRootAttribute root, String defaultNamespace)
   at System.Xml.Serialization.XmlSerializer..ctor(Type type, String defaultNamespace)
   at Emby.Server.Implementations.Serialization.MyXmlSerializer.GetSerializer(Type type)
   at Emby.Server.Implementations.Serialization.MyXmlSerializer.SerializeToWriter(Object obj, XmlWriter writer)
   at Emby.Server.Implementations.Serialization.MyXmlSerializer.SerializeToStream(Object obj, Stream stream)
   at Emby.Server.Implementations.Serialization.MyXmlSerializer.SerializeToFile(Object obj, String file)
   at MediaBrowser.Common.Plugins.BasePlugin1.SaveConfiguration()
   at MediaBrowser.Api.PluginService.Post(UpdatePluginConfiguration request)
   at Emby.Server.Implementations.Services.ServiceExecGeneral.GetTaskResult(Task task)
   at Emby.Server.Implementations.Services.ServiceHandler.ProcessRequestAsync(HttpListenerHost httpHost, IRequest httpReq, HttpResponse httpRes, ILogger logger, CancellationToken cancellationToken)
   at Emby.Server.Implementations.HttpServer.HttpListenerHost.RequestHandler(IHttpRequest httpReq, String urlString, String host, String localPath, CancellationToken cancellationToken)
```