### PR TITLE
Use Trakt last watched date when importing

### DIFF
--- a/Trakt/Api/DataContracts/Users/Watched/TraktShowWatched.cs
+++ b/Trakt/Api/DataContracts/Users/Watched/TraktShowWatched.cs
@@ -22,6 +22,8 @@ namespace Trakt.Api.DataContracts.Users.Watched
 
             public class Episode
             {
+                public string last_watched_at { get; set; }
+
                 public int number { get; set; }
 
                 public int plays { get; set; }

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -171,7 +171,16 @@ namespace Trakt.ScheduledTasks
                     if (!userData.Played)
                     {
                         userData.Played = true;
-                        userData.LastPlayedDate = DateTimeOffset.UtcNow.UtcDateTime;
+
+                        if (!string.IsNullOrEmpty(matchedMovie.last_watched_at))
+                        {
+                            userData.LastPlayedDate = DateTimeOffset.Parse(matchedMovie.last_watched_at).ToUniversalTime().UtcDateTime;        
+                        }
+                        else
+                        {
+                            userData.LastPlayedDate = DateTimeOffset.UtcNow.UtcDateTime;
+                        }
+
                         changed = true;
                     }
 
@@ -253,7 +262,16 @@ namespace Trakt.ScheduledTasks
                                 if (!userData.Played)
                                 {
                                     userData.Played = true;
-                                    userData.LastPlayedDate = DateTimeOffset.UtcNow.UtcDateTime;
+
+                                    if (!string.IsNullOrEmpty(matchedEpisode.last_watched_at))
+                                    {
+                                        userData.LastPlayedDate = DateTimeOffset.Parse(matchedEpisode.last_watched_at).ToUniversalTime().UtcDateTime;        
+                                    }
+                                    else
+                                    {
+                                        userData.LastPlayedDate = DateTimeOffset.UtcNow.UtcDateTime;
+                                    }
+
                                     changed = true;
                                 }
 

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -284,6 +284,18 @@ namespace Trakt.ScheduledTasks
                                     userData.PlayCount = playcount;
                                     changed = true;
                                 }
+
+                                // Set last played to whichever is most recent, remote or local time...
+                                if (!string.IsNullOrEmpty(matchedEpisode.last_watched_at))
+                                {
+                                    var tLastPlayed = DateTimeOffset.Parse(matchedEpisode.last_watched_at).ToUniversalTime();
+                                    var latestPlayed = tLastPlayed > userData.LastPlayedDate ? tLastPlayed.UtcDateTime : userData.LastPlayedDate;
+                                    if (userData.LastPlayedDate != latestPlayed)
+                                    {
+                                        userData.LastPlayedDate = latestPlayed;
+                                        changed = true;
+                                    }
+                                }
                             }
                         }
                         else if (!traktUser.SkipUnwatchedImportFromTrakt)


### PR DESCRIPTION
This pull request uses trakt last watched date when importing already watched items instead of the current timestamp.