### PR TITLE
Fix AUTHED_API_POST_LIMIT

### DIFF
--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -1109,27 +1109,28 @@ namespace Trakt.Api
             }
         }
 
-        private async Task<T> Retry<T>(Func<Task<T>> function)
+        private async Task<HttpResponseMessage> Retry(Func<Task<HttpResponseMessage>> function)
         {
-            try
+            HttpResponseMessage response = null;
+            for (int i = 0; i < 3; i++)
             {
-                return await function().ConfigureAwait(false);
+                try
+                {
+                    response = await function().ConfigureAwait(false);
+                    if (response.StatusCode == (HttpStatusCode) 429)
+                    {
+                        var delay = response.Headers.RetryAfter.Delta ?? TimeSpan.FromSeconds(1);
+                        await Task.Delay(delay).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                } catch {}
             }
-            catch
-            {
-            }
+   
 
-            await Task.Delay(500).ConfigureAwait(false);
-            try
-            {
-                return await function().ConfigureAwait(false);
-            }
-            catch
-            {
-            }
-
-            await Task.Delay(500).ConfigureAwait(false);
-            return await function().ConfigureAwait(false);
+            return response;
         }
 
         private HttpClient GetHttpClient()

--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -1036,7 +1036,7 @@ namespace Trakt.Api
 
             try
             {
-                var response = await Retry(async () => await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
+                var response = await RetryHttpRequest(async () => await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
                 return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             }
             finally
@@ -1100,7 +1100,7 @@ namespace Trakt.Api
 
             try
             {
-                var response = await Retry(async () => await httpClient.PostAsync(url, content, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
+                var response = await RetryHttpRequest(async () => await httpClient.PostAsync(url, content, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
                 return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             }
             finally
@@ -1109,7 +1109,7 @@ namespace Trakt.Api
             }
         }
 
-        private async Task<HttpResponseMessage> Retry(Func<Task<HttpResponseMessage>> function)
+        private async Task<HttpResponseMessage> RetryHttpRequest(Func<Task<HttpResponseMessage>> function)
         {
             HttpResponseMessage response = null;
             for (int i = 0; i < 3; i++)


### PR DESCRIPTION
Should Fix this issue: [https://github.com/jellyfin/jellyfin-plugin-trakt/issues/64](https://github.com/jellyfin/jellyfin-plugin-trakt/issues/64)

This Error message is still getting  spammed whenever you sync your library:
Trakt.ScheduledTasks.SyncLibraryTask: TraktResponse not Found: "{}"

But this should at least allow to sync the library again.