### PR TITLE
Prepare for release v12

### DIFF
--- a/Trakt/Trakt.csproj
+++ b/Trakt/Trakt.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <AssemblyVersion>11.0.0.0</AssemblyVersion>
-    <FileVersion>11.0.0.0</FileVersion>
+    <AssemblyVersion>12.0.0.0</AssemblyVersion>
+    <FileVersion>12.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "Trakt"
 guid: "4fe3201e-d6ae-4f2e-8917-e12bda571281"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-trakt.png"
-version: "11.0.0.0"
+version: "12.0.0.0"
 targetAbi: "10.7.0.0"
 framework: "net5.0"
 owner: "jellyfin"
@@ -13,4 +13,11 @@ category: "General"
 artifacts:
   - "Trakt.dll"
 changelog: |
-  changelog
+  - remove jQuery and update to es6 (#78) @grafixeyehero
+  - Use Trakt last watched date when importing (#63) @netpok
+  - Use System.Text.Json (#61) @Ullmie02
+  - chore: plugin images (#76) @h1dden-da3m0n
+  - Fix save button label (#72) @Vagab0nd
+  - Fix AUTHED_API_POST_LIMIT (#65) @dgalli1
+  - chore(deps): bump release-drafter/release-drafter from v5.14.0 to v5.15.0 (#68) @dependabot
+  - chore(ci): builds, releas drafter and more (#66) @h1dden-da3m0n


### PR DESCRIPTION
# Draft Changelog v12

- remove jQuery and update to es6 (#78) @grafixeyehero
- Use Trakt last watched date when importing (#63) @netpok
- Use System.Text.Json (#61) @Ullmie02
- chore: plugin images (#76) @h1dden-da3m0n
- Fix save button label (#72) @Vagab0nd
- Fix AUTHED_API_POST_LIMIT (#65) @dgalli1
- chore(deps): bump release-drafter/release-drafter from v5.14.0 to v5.15.0 (#68) @dependabot
- chore(ci): builds, releas drafter and more (#66) @h1dden-da3m0n