### PR TITLE
Don't treat TVDB Id specially for episodes

### DIFF
--- a/Trakt/Api/DataContracts/BaseModel/TraktEpisodeId.cs
+++ b/Trakt/Api/DataContracts/BaseModel/TraktEpisodeId.cs
@@ -1,13 +1,6 @@
 namespace Trakt.Api.DataContracts.BaseModel
 {
-    public class TraktEpisodeId : TraktId
+    public class TraktEpisodeId : TraktTVId
     {
-        public string imdb { get; set; }
-
-        public int? tmdb { get; set; }
-
-        public int? tvdb { get; set; }
-
-        public int? tvrage { get; set; }
     }
 }

--- a/Trakt/Api/DataContracts/BaseModel/TraktIMDBandTMDBId.cs
+++ b/Trakt/Api/DataContracts/BaseModel/TraktIMDBandTMDBId.cs
@@ -1,0 +1,9 @@
+namespace Trakt.Api.DataContracts.BaseModel
+{
+    public class TraktIMDBandTMDBId : TraktId
+    {
+        public string imdb { get; set; }
+
+        public int? tmdb { get; set; }
+    }
+}

--- a/Trakt/Api/DataContracts/BaseModel/TraktMovieId.cs
+++ b/Trakt/Api/DataContracts/BaseModel/TraktMovieId.cs
@@ -1,9 +1,6 @@
 namespace Trakt.Api.DataContracts.BaseModel
 {
-    public class TraktMovieId : TraktId
+    public class TraktMovieId : TraktIMDBandTMDBId
     {
-        public string imdb { get; set; }
-
-        public int? tmdb { get; set; }
     }
 }

--- a/Trakt/Api/DataContracts/BaseModel/TraktShowId.cs
+++ b/Trakt/Api/DataContracts/BaseModel/TraktShowId.cs
@@ -1,14 +1,7 @@
 ﻿
 namespace Trakt.Api.DataContracts.BaseModel
 {
-    public class TraktShowId : TraktId
+    public class TraktShowId : TraktTVId
     {
-        public string imdb { get; set; }
-
-        public int? tmdb { get; set; }
-
-        public int? tvdb { get; set; }
-
-        public int? tvrage { get; set; }
     }
 }

--- a/Trakt/Api/DataContracts/BaseModel/TraktTVId.cs
+++ b/Trakt/Api/DataContracts/BaseModel/TraktTVId.cs
@@ -1,7 +1,10 @@
+
 namespace Trakt.Api.DataContracts.BaseModel
 {
-    public class TraktPersonId : TraktIMDBandTMDBId
+    public class TraktTVId : TraktIMDBandTMDBId
     {
+        public int? tvdb { get; set; }
+
         public int? tvrage { get; set; }
     }
 }

--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -173,7 +173,6 @@ namespace Trakt.Api
         public async Task<List<TraktScrobbleResponse>> SendEpisodeStatusUpdateAsync(Episode episode, MediaStatus status, TraktUser traktUser, float progressPercent)
         {
             var episodeDatas = new List<TraktScrobbleEpisode>();
-            var tvDbId = episode.GetProviderId(MetadataProvider.Tvdb);
 
             var indexNumber = 0;
             var finalNumber = 0;


### PR DESCRIPTION
Removes special case handling based on presence of TVDB ID.

Updated CanSync and Scrobbling routines.
Not changed: Library update, and not sure what else might need changes.

Eventually should probably address #67, #80, #90

Submitting as a work in progress for feedback and automated checks.