### PR TITLE
Handle TV show rewatches

### DIFF
--- a/Trakt/Api/DataContracts/Users/Watched/TraktShowWatched.cs
+++ b/Trakt/Api/DataContracts/Users/Watched/TraktShowWatched.cs
@@ -10,6 +10,8 @@ namespace Trakt.Api.DataContracts.Users.Watched
 
         public string last_watched_at { get; set; }
 
+        public string reset_at { get; set; }
+
         public TraktShow show { get; set; }
 
         public List<Season> seasons { get; set; }


### PR DESCRIPTION
Adds support for the rewatch feature by comparing the `reset_at` date against `last_watched_at` date. If the episode has not been marked as _watched_ on trakt in the current rewatch cycle (i.e. the watch date is earlier than the reset date), the local episode is reset to _unwachted_ just like if it wasn't on the watched list in the first place.

This addresses #73 (if I understood that issue correctly).