### PR TITLE
Handle playback skipping and fix progress sync

### DIFF
--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -639,7 +639,7 @@ public class TraktApi
     /// <returns>Task{List{DataContracts.Users.Playback.TraktMoviePaused}}.</returns>
     public async Task<List<DataContracts.Users.Playback.TraktMoviePaused>> SendGetAllPausedMoviesRequest(TraktUser traktUser)
     {
-        return await GetFromTrakt<List<DataContracts.Users.Playback.TraktMoviePaused>>(TraktUris.PausedMovies, traktUser).ConfigureAwait(false);
+        return await GetFromTrakt<List<DataContracts.Users.Playback.TraktMoviePaused>>(TraktUris.PausedMovies + "?" + Random.Shared.NextInt64(), traktUser).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -649,7 +649,7 @@ public class TraktApi
     /// <returns>Task{List{DataContracts.Users.Playback.TraktEpisodePaused}}.</returns>
     public async Task<List<DataContracts.Users.Playback.TraktEpisodePaused>> SendGetPausedEpisodesRequest(TraktUser traktUser)
     {
-        return await GetFromTrakt<List<DataContracts.Users.Playback.TraktEpisodePaused>>(TraktUris.PausedEpisodes, traktUser).ConfigureAwait(false);
+        return await GetFromTrakt<List<DataContracts.Users.Playback.TraktEpisodePaused>>(TraktUris.PausedEpisodes + "?" + Random.Shared.NextInt64(), traktUser).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Trakt/Api/TraktURIs.cs
+++ b/Trakt/Api/TraktURIs.cs
@@ -93,12 +93,12 @@ public static class TraktUris
     /// <summary>
     /// The paused movies URI.
     /// </summary>
-    public const string PausedMovies = BaseUrl + "/sync/playback/movies";
+    public const string PausedMovies = BaseUrl + "/sync/playback/movies?start_at=2000-01-01T00:00:00.000Z";
 
     /// <summary>
     /// The paused shows URI.
     /// </summary>
-    public const string PausedEpisodes = BaseUrl + "/sync/playback/episodes";
+    public const string PausedEpisodes = BaseUrl + "/sync/playback/episodes?start_at=2000-01-01T00:00:00.000Z";
 
     /// <summary>
     /// The collected movies URI.

--- a/Trakt/Model/LibraryEvent.cs
+++ b/Trakt/Model/LibraryEvent.cs
@@ -1,8 +1,7 @@
 using MediaBrowser.Controller.Entities;
-using Trakt.Model;
 using Trakt.Model.Enums;
 
-namespace Trakt.Helpers;
+namespace Trakt.Model;
 
 internal class LibraryEvent
 {

--- a/Trakt/Model/PlaybackState.cs
+++ b/Trakt/Model/PlaybackState.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Trakt.Model;
 
 internal class PlaybackState

--- a/Trakt/Model/PlaybackState.cs
+++ b/Trakt/Model/PlaybackState.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Trakt.Model;
+
+internal class PlaybackState
+{
+    public bool IsPaused { get; set; } = false;
+
+    public long PlaybackProgress { get; set; } = 0L;
+}

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -13,7 +13,6 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 using MediaBrowser.Model.Tasks;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Trakt.Api;
 using Trakt.Api.DataContracts.Sync;

--- a/Trakt/ServerMediator.cs
+++ b/Trakt/ServerMediator.cs
@@ -31,7 +31,7 @@ public class ServerMediator : IServerEntryPoint, IDisposable
     private readonly UserDataManagerEventsHelper _userDataManagerEventsHelper;
     private readonly LibraryManagerEventsHelper _libraryManagerEventsHelper;
     private readonly TraktApi _traktApi;
-    private Dictionary<string, PlaybackState> _playbackState;
+    private readonly Dictionary<string, PlaybackState> _playbackState;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ServerMediator"/> class.


### PR DESCRIPTION
* implements playback skipping detection
* properly send status update to trakt on skip
* reducte API calls when playback is paused
* fix syncing playback progress from trakt to Jellyfin
* apply date query parameter and random offset parameter (just random offset did not work) to trakt playback sync URIs to circumvent caching