### PR TITLE
Prevent setting local item as unwatched on sync

### DIFF
--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -216,24 +216,9 @@ public class SyncLibraryTask : IScheduledTask
                     // If the movie has been played locally and is unplayed on trakt.tv then add it to the list
                     if (userData.Played)
                     {
-                        if (movieWatched == null)
+                        if (movieWatched == null && traktUser.PostWatchedHistory)
                         {
-                            if (traktUser.PostWatchedHistory)
-                            {
-                                playedMovies.Add(libraryMovie);
-                            }
-
-                            if (!traktUser.SkipUnwatchedImportFromTrakt)
-                            {
-                                userData.Played = false;
-
-                                _userDataManager.SaveUserData(
-                                    user.Id,
-                                    libraryMovie,
-                                    userData,
-                                    UserDataSaveReason.Import,
-                                    cancellationToken);
-                            }
+                            playedMovies.Add(libraryMovie);
                         }
                     }
                     else


### PR DESCRIPTION
No idea how that was intended to work...

Currently a watched item on trakt is marked as watched while being marked as unwatched locally.
This change does not mark it unwatched locally but just syncs the watched state to trakt.

Fixes #151