### PR TITLE
Do not hammer the API

### DIFF
--- a/Trakt/Api/DataContracts/Users/Playback/TraktEpisodePaused.cs
+++ b/Trakt/Api/DataContracts/Users/Playback/TraktEpisodePaused.cs
@@ -21,13 +21,13 @@ public class TraktEpisodePaused
     public int Id { get; set; }
 
     /// <summary>
-    /// Gets or sets the type.
+    /// Gets or sets the paused datetime.
     /// </summary>
     [JsonPropertyName("paused_at")]
     public string PausedAt { get; set; }
 
     /// <summary>
-    /// Gets or sets the movie year.
+    /// Gets or sets the progress.
     /// </summary>
     [JsonPropertyName("progress")]
     public double Progress { get; set; }

--- a/Trakt/Api/DataContracts/Users/Playback/TraktMoviePaused.cs
+++ b/Trakt/Api/DataContracts/Users/Playback/TraktMoviePaused.cs
@@ -21,13 +21,13 @@ public class TraktMoviePaused
     public TraktMovie Movie { get; set; }
 
     /// <summary>
-    /// Gets or sets the type.
+    /// Gets or sets the paused datetime.
     /// </summary>
     [JsonPropertyName("paused_at")]
     public string PausedAt { get; set; }
 
     /// <summary>
-    /// Gets or sets the movie year.
+    /// Gets or sets the progress.
     /// </summary>
     [JsonPropertyName("progress")]
     public double Progress { get; set; }

--- a/Trakt/Api/TraktURIs.cs
+++ b/Trakt/Api/TraktURIs.cs
@@ -13,7 +13,7 @@ public static class TraktUris
     /// <summary>
     /// The client id.
     /// </summary>
-    public const string ClientId = "58f2251f1c9e7275e94fef723a8604e6848bbf86a0d97dda82382a6c3231608c";
+    public const string ClientId = "bfdd2e032c30c35b368f97ef4ec81587b899bcb028b91a1d4ba5589a4b6a7267";
 
     /// <summary>
     /// The client secret.

--- a/Trakt/Api/TraktURIs.cs
+++ b/Trakt/Api/TraktURIs.cs
@@ -119,14 +119,4 @@ public static class TraktUris
     /// The shows recommendations URI.
     /// </summary>
     public const string RecommendationsShows = BaseUrl + "/recommendations/shows";
-
-    /// <summary>
-    /// The movies recommendations dismiss URI.
-    /// </summary>
-    public const string RecommendationsMoviesDismiss = BaseUrl + "/recommendations/movies/{0}";
-
-    /// <summary>
-    /// The shows recommendations dismiss URI.
-    /// </summary>
-    public const string RecommendationsShowsDismiss = BaseUrl + "/recommendations/shows/{0}";
 }

--- a/Trakt/Model/PlaybackState.cs
+++ b/Trakt/Model/PlaybackState.cs
@@ -6,7 +6,7 @@ internal class PlaybackState
 {
     public bool IsPaused { get; set; } = false;
 
-    public long PlaybackProgress { get; set; } = 0L;
+    public long PlaybackPositionTicks { get; set; } = 0L;
 
-    public DateTime PlaybackTime { get; set; } = DateTime.Now;
+    public DateTime PlaybackTime { get; set; } = DateTime.UtcNow;
 }

--- a/Trakt/Model/PlaybackState.cs
+++ b/Trakt/Model/PlaybackState.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Trakt.Model;
 
 internal class PlaybackState
@@ -5,4 +7,6 @@ internal class PlaybackState
     public bool IsPaused { get; set; } = false;
 
     public long PlaybackProgress { get; set; } = 0L;
+
+    public DateTime PlaybackTime { get; set; } = DateTime.Now;
 }

--- a/Trakt/ServerMediator.cs
+++ b/Trakt/ServerMediator.cs
@@ -224,40 +224,40 @@ public class ServerMediator : IServerEntryPoint, IDisposable
             }
 
             var video = playbackProgressEventArgs.Item as Video;
-            var progressPercent = video.RunTimeTicks.HasValue && video.RunTimeTicks != 0 ?
-                (float)(playbackProgressEventArgs.PlaybackPositionTicks ?? 0) / video.RunTimeTicks.Value * 100.0f : 0.0f;
+            var playbackPositionTicks = playbackProgressEventArgs.PlaybackPositionTicks ?? 0L;
+            var progressPercent = video.RunTimeTicks.HasValue && video.RunTimeTicks != 0
+                                    ? (float)playbackPositionTicks / video.RunTimeTicks.Value * 100.0f
+                                    : 0.0f;
 
             _logger.LogDebug("User {User} started watching item {Item}.", user.Username, playbackProgressEventArgs.Item.Path);
 
             try
             {
-                if (video is Movie movie)
+                _playbackState[traktUser.LinkedMbUserId] = new PlaybackState
                 {
-                    _playbackState[traktUser.LinkedMbUserId] = new PlaybackState();
-                    _playbackState[traktUser.LinkedMbUserId].PlaybackProgress = playbackProgressEventArgs.PlaybackPositionTicks ?? 0L;
-                    _playbackState[traktUser.LinkedMbUserId].IsPaused = false;
-                    _playbackState[traktUser.LinkedMbUserId].PlaybackTime = DateTime.UtcNow;
+                    IsPaused = false,
+                    PlaybackPositionTicks = playbackPositionTicks,
+                    PlaybackTime = DateTime.UtcNow
+                };
 
-                    _logger.LogDebug("Sending movie playback status update to trakt.tv for user {User}.", user.Username);
-                    await _traktApi.SendMovieStatusUpdateAsync(
-                        movie,
-                        MediaStatus.Watching,
-                        traktUser,
-                        progressPercent).ConfigureAwait(false);
-                }
-                else if (video is Episode episode)
+                _logger.LogDebug("Sending {VideoType} playback status (Watching) update to trakt.tv for user {User}.", video.GetType().Name, user.Username);
+
+                switch (video)
                 {
-                    _playbackState[traktUser.LinkedMbUserId] = new PlaybackState();
-                    _playbackState[traktUser.LinkedMbUserId].PlaybackProgress = playbackProgressEventArgs.PlaybackPositionTicks ?? 0L;
-                    _playbackState[traktUser.LinkedMbUserId].IsPaused = false;
-                    _playbackState[traktUser.LinkedMbUserId].PlaybackTime = DateTime.UtcNow;
-
-                    _logger.LogDebug("Sending episode playback status update to trakt.tv for user {User}.", user.Username);
-                    await _traktApi.SendEpisodeStatusUpdateAsync(
-                        episode,
-                        MediaStatus.Watching,
-                        traktUser,
-                        progressPercent).ConfigureAwait(false);
+                    case Movie movie:
+                        await _traktApi.SendMovieStatusUpdateAsync(
+                            movie,
+                            MediaStatus.Watching,
+                            traktUser,
+                            progressPercent).ConfigureAwait(false);
+                        break;
+                    case Episode episode:
+                        await _traktApi.SendEpisodeStatusUpdateAsync(
+                            episode,
+                            MediaStatus.Watching,
+                            traktUser,
+                            progressPercent).ConfigureAwait(false);
+                        break;
                 }
             }
             catch (Exception ex)
@@ -314,146 +314,67 @@ public class ServerMediator : IServerEntryPoint, IDisposable
             if (!_playbackState.TryGetValue(traktUser.LinkedMbUserId, out var state))
             {
                 state = new PlaybackState();
-                _playbackState[traktUser.LinkedMbUserId] = state;
             }
 
             var video = playbackProgressEventArgs.Item as Video;
-            var playbackPositionTicks = playbackProgressEventArgs.PlaybackPositionTicks;
-            var realTimeDifferenceInSeconds = (DateTime.UtcNow - state.PlaybackTime).TotalSeconds;
-            var tickDifferenceInSeconds = TimeSpan.FromTicks((playbackPositionTicks ?? 0L) - state.PlaybackProgress).TotalSeconds;
+            var playbackPositionTicks = playbackProgressEventArgs.PlaybackPositionTicks ?? 0L;
+            var realTimeDifferenceInSeconds = Math.Round((DateTime.UtcNow - state.PlaybackTime).TotalSeconds);
+            var tickDifferenceInSeconds = Math.Round(TimeSpan.FromTicks(playbackPositionTicks - state.PlaybackPositionTicks).TotalSeconds);
             var progressPercent = video.RunTimeTicks.HasValue && video.RunTimeTicks != 0
-                                    ? (float)(playbackPositionTicks ?? 0) / video.RunTimeTicks.Value * 100.0f
+                                    ? (float)playbackPositionTicks / video.RunTimeTicks.Value * 100.0f
                                     : 0.0f;
-
-            _logger.LogDebug("User {User} progressed watching item {Item}.", user.Username, playbackProgressEventArgs.Item.Path);
 
             try
             {
-                if (playbackProgressEventArgs.IsPaused)
+                if (!_playbackState.TryGetValue(traktUser.LinkedMbUserId, out state))
                 {
-                    if (!state.IsPaused)
+                    _logger.LogWarning("Received playback progress from user {User} but initial state was never set - setting it now!", user.Username);
+                    _playbackState[traktUser.LinkedMbUserId] = new PlaybackState
                     {
-                        _logger.LogDebug("Playback paused");
-                        if (video is Movie movie)
-                        {
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackProgress = playbackPositionTicks ?? 0L;
-                            _playbackState[traktUser.LinkedMbUserId].IsPaused = true;
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackTime = DateTime.UtcNow;
-
-                            _logger.LogDebug("Sending movie playback status update to trakt.tv for user {User}.", user.Username);
-                            await _traktApi.SendMovieStatusUpdateAsync(
-                                movie,
-                                MediaStatus.Paused,
-                                traktUser,
-                                progressPercent).ConfigureAwait(false);
-                        }
-                        else if (video is Episode episode)
-                        {
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackProgress = playbackProgressEventArgs.PlaybackPositionTicks ?? 0L;
-                            _playbackState[traktUser.LinkedMbUserId].IsPaused = false;
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackTime = DateTime.UtcNow;
-
-                            _logger.LogDebug("Sending episode playback status update to trakt.tv for user {User}.", user.Username);
-                            await _traktApi.SendEpisodeStatusUpdateAsync(
-                                episode,
-                                MediaStatus.Paused,
-                                traktUser,
-                                progressPercent).ConfigureAwait(false);
-                        }
-                    }
-                    else if (tickDifferenceInSeconds < 0 || tickDifferenceInSeconds > realTimeDifferenceInSeconds + 15)
-                    {
-                        _logger.LogDebug("Playback skipped");
-                        if (video is Movie movie)
-                        {
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackProgress = playbackPositionTicks ?? 0L;
-                            _playbackState[traktUser.LinkedMbUserId].IsPaused = true;
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackTime = DateTime.UtcNow;
-
-                            _logger.LogDebug("Sending movie playback status update to trakt.tv for user {User}.", user.Username);
-                            await _traktApi.SendMovieStatusUpdateAsync(
-                                movie,
-                                MediaStatus.Paused,
-                                traktUser,
-                                progressPercent).ConfigureAwait(false);
-                        }
-                        else if (video is Episode episode)
-                        {
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackProgress = playbackPositionTicks ?? 0L;
-                            _playbackState[traktUser.LinkedMbUserId].IsPaused = true;
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackTime = DateTime.UtcNow;
-
-                            _logger.LogDebug("Sending episode playback status update to trakt.tv for user {User}.", user.Username);
-                            await _traktApi.SendEpisodeStatusUpdateAsync(
-                                episode,
-                                MediaStatus.Paused,
-                                traktUser,
-                                progressPercent).ConfigureAwait(false);
-                        }
-                    }
+                        IsPaused = false,
+                        PlaybackPositionTicks = playbackPositionTicks,
+                        PlaybackTime = DateTime.UtcNow
+                    };
+                    continue;
                 }
-                else
+
+                state.PlaybackPositionTicks = playbackPositionTicks;
+                state.PlaybackTime = DateTime.UtcNow;
+
+                // Mark as skipped if tick difference is less than -10 seconds
+                // or tick difference is ahead of real time difference by more than 10 seconds.
+                var playbackSkipped = tickDifferenceInSeconds < -10 || tickDifferenceInSeconds > realTimeDifferenceInSeconds + 10;
+                if (playbackProgressEventArgs.IsPaused == state.IsPaused && !playbackSkipped)
                 {
-                    if (state.IsPaused)
-                    {
-                        _logger.LogDebug("Playback resumed");
-                        if (video is Movie movie)
-                        {
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackProgress = playbackProgressEventArgs.PlaybackPositionTicks ?? 0L;
-                            _playbackState[traktUser.LinkedMbUserId].IsPaused = false;
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackTime = DateTime.UtcNow;
+                    _logger.LogDebug("Playback state did not change.");
+                    continue;
+                }
 
-                            _logger.LogDebug("Sending movie playback status update to trakt.tv for user {User}.", user.Username);
-                            await _traktApi.SendMovieStatusUpdateAsync(
-                                movie,
-                                MediaStatus.Watching,
-                                traktUser,
-                                progressPercent).ConfigureAwait(false);
-                        }
-                        else if (video is Episode episode)
-                        {
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackProgress = playbackProgressEventArgs.PlaybackPositionTicks ?? 0L;
-                            _playbackState[traktUser.LinkedMbUserId].IsPaused = false;
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackTime = DateTime.UtcNow;
+                if (playbackSkipped)
+                {
+                    _logger.LogDebug("Playback skipped.");
+                }
 
-                            _logger.LogDebug("Sending episode playback status update to trakt.tv for user {User}.", user.Username);
-                            await _traktApi.SendEpisodeStatusUpdateAsync(
-                                episode,
-                                MediaStatus.Watching,
-                                traktUser,
-                                progressPercent).ConfigureAwait(false);
-                        }
-                    }
-                    else if (tickDifferenceInSeconds < 0 || tickDifferenceInSeconds > realTimeDifferenceInSeconds + 15)
-                    {
-                        _logger.LogDebug("Playback skipped");
-                        if (video is Movie movie)
-                        {
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackProgress = playbackProgressEventArgs.PlaybackPositionTicks ?? 0L;
-                            _playbackState[traktUser.LinkedMbUserId].IsPaused = false;
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackTime = DateTime.UtcNow;
+                state.IsPaused = playbackProgressEventArgs.IsPaused;
+                var status = state.IsPaused ? MediaStatus.Paused : MediaStatus.Watching;
+                _logger.LogDebug("Sending {VideoType} playback status ({PlaybackStatus}) update to trakt.tv for user {User}.", video.GetType().Name, status, user.Username);
 
-                            _logger.LogDebug("Sending movie playback status update to trakt.tv for user {User}.", user.Username);
-                            await _traktApi.SendMovieStatusUpdateAsync(
-                                movie,
-                                MediaStatus.Watching,
-                                traktUser,
-                                progressPercent).ConfigureAwait(false);
-                        }
-                        else if (video is Episode episode)
-                        {
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackProgress = playbackProgressEventArgs.PlaybackPositionTicks ?? 0L;
-                            _playbackState[traktUser.LinkedMbUserId].IsPaused = false;
-                            _playbackState[traktUser.LinkedMbUserId].PlaybackTime = DateTime.UtcNow;
-
-                            _logger.LogDebug("Sending episode playback status update to trakt.tv for user {User}.", user.Username);
-                            await _traktApi.SendEpisodeStatusUpdateAsync(
-                                episode,
-                                MediaStatus.Watching,
-                                traktUser,
-                                progressPercent).ConfigureAwait(false);
-                        }
-                    }
+                switch (video)
+                {
+                    case Movie movie:
+                        await _traktApi.SendMovieStatusUpdateAsync(
+                            movie,
+                            status,
+                            traktUser,
+                            progressPercent).ConfigureAwait(false);
+                        break;
+                    case Episode episode:
+                        await _traktApi.SendEpisodeStatusUpdateAsync(
+                            episode,
+                            status,
+                            traktUser,
+                            progressPercent).ConfigureAwait(false);
+                        break;
                 }
             }
             catch (Exception ex)
@@ -483,7 +404,7 @@ public class ServerMediator : IServerEntryPoint, IDisposable
             return;
         }
 
-        _logger.LogInformation("Playback stopped");
+        _logger.LogDebug("Playback stopped");
 
         foreach (var user in playbackStoppedEventArgs.Users)
         {
@@ -514,24 +435,24 @@ public class ServerMediator : IServerEntryPoint, IDisposable
                 if (playbackStoppedEventArgs.PlayedToCompletion)
                 {
                     _logger.LogDebug("User {User} completed watching item {Item}. Scrobbling.", user.Username, playbackStoppedEventArgs.Item.Name);
+                    _logger.LogDebug("Sending {VideoType} playback status (Stop) update to trakt.tv for user {User}.", video.GetType().Name, user.Username);
 
-                    if (video is Movie movie)
+                    switch (video)
                     {
-                        _logger.LogDebug("Sending movie playback status update to trakt.tv for user {User}.", user.Username);
-                        await _traktApi.SendMovieStatusUpdateAsync(
-                            movie,
-                            MediaStatus.Stop,
-                            traktUser,
-                            100).ConfigureAwait(false);
-                    }
-                    else if (video is Episode episode)
-                    {
-                        _logger.LogDebug("Sending episode playback status update to trakt.tv for user {User}.", user.Username);
-                        await _traktApi.SendEpisodeStatusUpdateAsync(
-                            episode,
-                            MediaStatus.Stop,
-                            traktUser,
-                            100).ConfigureAwait(false);
+                        case Movie movie:
+                            await _traktApi.SendMovieStatusUpdateAsync(
+                                movie,
+                                MediaStatus.Stop,
+                                traktUser,
+                                100).ConfigureAwait(false);
+                            break;
+                        case Episode episode:
+                            await _traktApi.SendEpisodeStatusUpdateAsync(
+                                episode,
+                                MediaStatus.Stop,
+                                traktUser,
+                                100).ConfigureAwait(false);
+                            break;
                     }
                 }
                 else
@@ -541,21 +462,22 @@ public class ServerMediator : IServerEntryPoint, IDisposable
 
                     _logger.LogDebug("User {User} didn't watch item {Item} until the end. Not scrobbling but pausing playback at current playback position.", user.Username, playbackStoppedEventArgs.Item.Name);
 
-                    if (video is Movie movie)
+                    switch (video)
                     {
-                        await _traktApi.SendMovieStatusUpdateAsync(
-                            movie,
-                            MediaStatus.Paused,
-                            traktUser,
-                            progressPercent).ConfigureAwait(false);
-                    }
-                    else if (video is Episode episode)
-                    {
-                        await _traktApi.SendEpisodeStatusUpdateAsync(
-                            episode,
-                            MediaStatus.Paused,
-                            traktUser,
-                            progressPercent).ConfigureAwait(false);
+                        case Movie movie:
+                            await _traktApi.SendMovieStatusUpdateAsync(
+                                movie,
+                                MediaStatus.Paused,
+                                traktUser,
+                                progressPercent).ConfigureAwait(false);
+                            break;
+                        case Episode episode:
+                            await _traktApi.SendEpisodeStatusUpdateAsync(
+                                episode,
+                                MediaStatus.Paused,
+                                traktUser,
+                                progressPercent).ConfigureAwait(false);
+                            break;
                     }
                 }
 


### PR DESCRIPTION
Since clients do not send playback updates in a consistent schedule, we need to account for that to not hammer the trakt API.
* Save timestamps of processed events
* Compare timestamp difference to runtime tick difference to recognize skips
* Properly handle skips when paused
* Minimum skipping time is 10 seconds in both directions
* Set local state before calling the API to not lose the local state if the API call fails

I also included some minor spelling fixes and cleanups I had stashed.

----
Fixes #174 