### PR TITLE
Fix episode matching for sync from trakt task

### DIFF
--- a/Trakt/Api/DataContracts/Sync/History/TraktEpisodeWatchedHistory.cs
+++ b/Trakt/Api/DataContracts/Sync/History/TraktEpisodeWatchedHistory.cs
@@ -1,0 +1,40 @@
+﻿using System.Text.Json.Serialization;
+using Trakt.Api.DataContracts.BaseModel;
+
+namespace Trakt.Api.DataContracts.Sync.History;
+
+/// <summary>
+/// The trakt.tv sync episode watched history class.
+/// </summary>
+public class TraktEpisodeWatchedHistory
+{
+    /// <summary>
+    /// Gets or sets the watched date.
+    /// </summary>
+    [JsonPropertyName("watched_at")]
+    public string WatchedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the action.
+    /// </summary>
+    [JsonPropertyName("action")]
+    public string Action { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the episode.
+    /// </summary>
+    [JsonPropertyName("episode")]
+    public TraktEpisode Episode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the episode.
+    /// </summary>
+    [JsonPropertyName("show")]
+    public TraktShow Show { get; set; }
+}

--- a/Trakt/Api/DataContracts/Sync/History/TraktMovieWatchedHistory.cs
+++ b/Trakt/Api/DataContracts/Sync/History/TraktMovieWatchedHistory.cs
@@ -1,0 +1,34 @@
+﻿using System.Text.Json.Serialization;
+using Trakt.Api.DataContracts.BaseModel;
+
+namespace Trakt.Api.DataContracts.Sync.History;
+
+/// <summary>
+/// The trakt.tv sync movie watched history class.
+/// </summary>
+public class TraktMovieWatchedHistory
+{
+    /// <summary>
+    /// Gets or sets the watched date.
+    /// </summary>
+    [JsonPropertyName("watched_at")]
+    public string WatchedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the action.
+    /// </summary>
+    [JsonPropertyName("action")]
+    public string Action { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the movie.
+    /// </summary>
+    [JsonPropertyName("movie")]
+    public TraktMovie Movie { get; set; }
+}

--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -1131,7 +1131,7 @@ public class TraktApi
 
                 response.EnsureSuccessStatusCode();
                 var tmpResult = await response.Content.ReadFromJsonAsync<List<T>>(_jsonOptions, cancellationToken).ConfigureAwait(false);
-                if (result.GetType().IsGenericType && result.GetType().GetGenericTypeDefinition() == typeof(List<>))
+                if (tmpResult != null)
                 {
                     result.AddRange(tmpResult);
                 }

--- a/Trakt/Api/TraktURIs.cs
+++ b/Trakt/Api/TraktURIs.cs
@@ -51,6 +51,16 @@ public static class TraktUris
     public const string SyncCollectionRemove = BaseUrl + "/sync/collection/remove";
 
     /// <summary>
+    /// The watched movies history URI.
+    /// </summary>
+    public const string SyncWatchedMoviesHistory = BaseUrl + "/sync/history/movies?page={page}&limit=1000";
+
+    /// <summary>
+    /// The watched episodes history URI.
+    /// </summary>
+    public const string SyncWatchedEpisodesHistory = BaseUrl + "/sync/history/episodes?page={page}&limit=1000";
+
+    /// <summary>
     /// The watched history add URI.
     /// </summary>
     public const string SyncWatchedHistoryAdd = BaseUrl + "/sync/history";

--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -7,6 +7,7 @@ using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Model.Entities;
 using Trakt.Api.DataContracts.BaseModel;
+using Trakt.Api.DataContracts.Sync.History;
 using Trakt.Api.DataContracts.Users.Collection;
 using Trakt.Api.DataContracts.Users.Playback;
 using Trakt.Api.DataContracts.Users.Watched;
@@ -422,6 +423,28 @@ public static class Extensions
     public static TraktMoviePaused FindMatch(BaseItem item, IEnumerable<TraktMoviePaused> results)
     {
         return results.FirstOrDefault(i => IsMatch(item, i.Movie));
+    }
+
+    /// <summary>
+    /// Gets a watched history match for a movie.
+    /// </summary>
+    /// <param name="item">The <see cref="BaseItem"/>.</param>
+    /// <param name="results">>The <see cref="IEnumerable{TraktMovieWatchedHistory}"/>.</param>
+    /// <returns>TraktMovieWatchedHistory.</returns>
+    public static TraktMovieWatchedHistory FindMatch(Movie item, IEnumerable<TraktMovieWatchedHistory> results)
+    {
+        return results.FirstOrDefault(i => IsMatch(item, i.Movie));
+    }
+
+    /// <summary>
+    /// Gets a watched history match for an episode.
+    /// </summary>
+    /// <param name="item">The <see cref="BaseItem"/>.</param>
+    /// <param name="results">>The <see cref="IEnumerable{TraktEpisodeWatchedHistory}"/>.</param>
+    /// <returns>TraktMovieWatchedHistory.</returns>
+    public static TraktEpisodeWatchedHistory FindMatch(Episode item, IEnumerable<TraktEpisodeWatchedHistory> results)
+    {
+        return results.FirstOrDefault(i => IsMatch(item, i.Episode));
     }
 
     /// <summary>

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -353,9 +353,24 @@ public class SyncFromTraktTask : IScheduledTask
                         // Fallback procedure to find match by using episode history
                         if (matchedWatchedEpisode == null && matchedWatchedEpisodeHistory != null)
                         {
-                            // Find watched season via history match
-                            _logger.LogDebug("Using history to match episode for user {User} for {Data}", user.Username, GetVerboseEpisodeData(episode));
+                            // Find watched season and episode via history match
+                            _logger.LogDebug("Using history to match season and episode for user {User} for {Data}", user.Username, GetVerboseEpisodeData(episode));
                             matchedWatchedEpisode = matchedWatchedSeason.Episodes.FirstOrDefault(tEpisode => tEpisode.Number == matchedWatchedEpisodeHistory.Episode.Number);
+                        }
+
+                        // Fallback procedure to find match by using episode history, without checking the season (episode can belong to different season)
+                        if (matchedWatchedEpisode == null && matchedWatchedEpisodeHistory != null)
+                        {
+                            // Find watched episode via history match
+                            _logger.LogDebug("Using history to match episode for user {User} for {Data}", user.Username, GetVerboseEpisodeData(episode));
+                            foreach (var season in matchedWatchedShow.Seasons)
+                            {
+                                matchedWatchedEpisode = season.Episodes.FirstOrDefault(tEpisode => tEpisode.Number == matchedWatchedEpisodeHistory.Episode.Number);
+                                if (matchedWatchedEpisode != null)
+                                {
+                                    break; // stop when found in a season
+                                }
+                            }
                         }
 
                         // Prepend a check if the matched episode is on a rewatch cycle and


### PR DESCRIPTION
Explanation:
- Trakt has switched from tvdb to tmdb as indexer
- Episodes are often not aligned between tvdb and tmdb
- Watched shows api does not contain episodes ids
- History api does contain episode ids (not only season and number)
- If no matching is found by season and number (from shows api), fallback to history api to determine a match by episode ids

Fixes https://github.com/jellyfin/jellyfin-plugin-trakt/issues/190