### PR TITLE
Use history api for importing episodes from trakt

### DIFF
--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -559,15 +559,19 @@ public static class Extensions
     /// <returns><see cref="bool"/> indicating if the <see cref="Episode"/> matches a <see cref="TraktEpisodeWatchedHistory"/>.</returns>
     public static bool IsMatch(Episode item, TraktEpisodeWatchedHistory episodeHistory)
     {
+        bool match = false;
+
         // Match by provider id's if available, Match by show, season and episode number if not
-        if (HasAnyProviderTvIds(item))
+        if (HasAnyProviderTvIds(item) && HasAnyProviderTvIds(episodeHistory.Episode))
         {
-            return IsMatch(item, episodeHistory.Episode);
+            match = IsMatch(item, episodeHistory.Episode);
         }
         else
         {
-            return IsMatch(item.Series, episodeHistory.Show) && item.GetSeasonNumber() == episodeHistory.Episode.Season && item.ContainsEpisodeNumber(episodeHistory.Episode.Number);
+            match = IsMatch(item.Series, episodeHistory.Show) && item.GetSeasonNumber() == episodeHistory.Episode.Season && item.ContainsEpisodeNumber(episodeHistory.Episode.Number);
         }
+
+        return match;
     }
 
     private static bool HasAnyProviderTvIds(Episode item)
@@ -576,5 +580,13 @@ public static class Extensions
             || item.HasProviderId(MetadataProvider.Tmdb)
             || item.HasProviderId(MetadataProvider.Imdb)
             || item.HasProviderId(MetadataProvider.TvRage);
+    }
+
+    private static bool HasAnyProviderTvIds(TraktEpisode item)
+    {
+        return item.Ids.Tvdb != null
+            || item.Ids.Tmdb != null
+            || item.Ids.Imdb != null
+            || item.Ids.Tvrage != null;
     }
 }

--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -565,12 +565,20 @@ public static class Extensions
             return true;
         }
 
-        // Match by show, season and episode number
-        if (IsMatch(item.Series, episodeHistory.Show) && item.GetSeasonNumber() == episodeHistory.Episode.Season && item.ContainsEpisodeNumber(episodeHistory.Episode.Number))
+        // Match by show, season and episode number if no provider id's are available
+        if (!HasAnyProviderTvIds(item) && IsMatch(item.Series, episodeHistory.Show) && item.GetSeasonNumber() == episodeHistory.Episode.Season && item.ContainsEpisodeNumber(episodeHistory.Episode.Number))
         {
             return true;
         }
 
         return false;
+    }
+
+    private static bool HasAnyProviderTvIds(BaseItem item)
+    {
+        return item.HasProviderId(MetadataProvider.Imdb)
+               || item.HasProviderId(MetadataProvider.Tmdb)
+               || item.HasProviderId(MetadataProvider.Tvdb)
+               || item.HasProviderId(MetadataProvider.TvRage);
     }
 }

--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -567,7 +567,7 @@ public static class Extensions
 
         // Match by show, season and episode number if there isn't any provider id in common
         // If there was a common provider id between the item and the trakt episode (f.e. both have tvdb id), you shouldn't check anymore by season/number
-        if (HasAnyProviderTvIdInCommon(item, episodeHistory.Episode)
+        if (!HasAnyProviderTvIdInCommon(item, episodeHistory.Episode)
             && IsMatch(item.Series, episodeHistory.Show)
             && item.GetSeasonNumber() == episodeHistory.Episode.Season
             && item.ContainsEpisodeNumber(episodeHistory.Episode.Number))

--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -455,7 +455,7 @@ public static class Extensions
     /// <returns>IEnumerable{TraktEpisodeWatchedHistory}.</returns>
     public static IEnumerable<TraktEpisodeWatchedHistory> FindAllMatches(Episode item, IEnumerable<TraktEpisodeWatchedHistory> results)
     {
-        return results.Where(i => IsMatch(item, i.Episode)).AsEnumerable();
+        return results.Where(i => IsMatch(item, i)).AsEnumerable();
     }
 
     /// <summary>
@@ -548,7 +548,42 @@ public static class Extensions
             return true;
         }
 
-        if (item.GetSeasonNumber() == episode.Season && item.ContainsEpisodeNumber(episode.Number))
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if a <see cref="Episode"/> matches a <see cref="TraktEpisodeWatchedHistory"/>.
+    /// </summary>
+    /// <param name="item">The <see cref="Episode"/>.</param>
+    /// <param name="episodeHistory">The <see cref="TraktEpisodeWatchedHistory"/>.</param>
+    /// <returns><see cref="bool"/> indicating if the <see cref="Episode"/> matches a <see cref="TraktEpisodeWatchedHistory"/>.</returns>
+    public static bool IsMatch(Episode item, TraktEpisodeWatchedHistory episodeHistory)
+    {
+        var tvdb = item.GetProviderId(MetadataProvider.Tvdb);
+        if (!string.IsNullOrEmpty(tvdb) && string.Equals(tvdb, episodeHistory.Episode.Ids.Tvdb, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var tmdb = item.GetProviderId(MetadataProvider.Tmdb);
+        if (!string.IsNullOrEmpty(tmdb) && string.Equals(tmdb, episodeHistory.Episode.Ids.Tmdb.ToString(), StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var imdb = item.GetProviderId(MetadataProvider.Imdb);
+        if (!string.IsNullOrEmpty(imdb) && string.Equals(imdb, episodeHistory.Episode.Ids.Imdb, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var tvrage = item.GetProviderId(MetadataProvider.TvRage);
+        if (!string.IsNullOrEmpty(tvrage) && string.Equals(tvrage, episodeHistory.Episode.Ids.Tvrage, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (IsMatch(item.Series, episodeHistory.Show) && item.GetSeasonNumber() == episodeHistory.Episode.Season && item.ContainsEpisodeNumber(episodeHistory.Episode.Number))
         {
             return true;
         }

--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -559,34 +559,18 @@ public static class Extensions
     /// <returns><see cref="bool"/> indicating if the <see cref="Episode"/> matches a <see cref="TraktEpisodeWatchedHistory"/>.</returns>
     public static bool IsMatch(Episode item, TraktEpisodeWatchedHistory episodeHistory)
     {
-        bool match = false;
-
-        // Match by provider id's if available, Match by show, season and episode number if not
-        if (HasAnyProviderTvIds(item) && HasAnyProviderTvIds(episodeHistory.Episode))
+        // Match by provider id's
+        if (IsMatch(item, episodeHistory.Episode))
         {
-            match = IsMatch(item, episodeHistory.Episode);
-        }
-        else
-        {
-            match = IsMatch(item.Series, episodeHistory.Show) && item.GetSeasonNumber() == episodeHistory.Episode.Season && item.ContainsEpisodeNumber(episodeHistory.Episode.Number);
+            return true;
         }
 
-        return match;
-    }
+        // Match by show, season and episode number
+        if (IsMatch(item.Series, episodeHistory.Show) && item.GetSeasonNumber() == episodeHistory.Episode.Season && item.ContainsEpisodeNumber(episodeHistory.Episode.Number))
+        {
+            return true;
+        }
 
-    private static bool HasAnyProviderTvIds(Episode item)
-    {
-        return item.HasProviderId(MetadataProvider.Tvdb)
-            || item.HasProviderId(MetadataProvider.Tmdb)
-            || item.HasProviderId(MetadataProvider.Imdb)
-            || item.HasProviderId(MetadataProvider.TvRage);
-    }
-
-    private static bool HasAnyProviderTvIds(TraktEpisode item)
-    {
-        return item.Ids.Tvdb != null
-            || item.Ids.Tmdb != null
-            || item.Ids.Imdb != null
-            || item.Ids.Tvrage != null;
+        return false;
     }
 }

--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -441,10 +441,21 @@ public static class Extensions
     /// </summary>
     /// <param name="item">The <see cref="BaseItem"/>.</param>
     /// <param name="results">>The <see cref="IEnumerable{TraktEpisodeWatchedHistory}"/>.</param>
-    /// <returns>TraktMovieWatchedHistory.</returns>
+    /// <returns>TraktEpisodeWatchedHistory.</returns>
     public static TraktEpisodeWatchedHistory FindMatch(Episode item, IEnumerable<TraktEpisodeWatchedHistory> results)
     {
         return results.FirstOrDefault(i => IsMatch(item, i.Episode));
+    }
+
+    /// <summary>
+    /// Gets all watched history matches for an episode.
+    /// </summary>
+    /// <param name="item">The <see cref="BaseItem"/>.</param>
+    /// <param name="results">>The <see cref="IEnumerable{TraktEpisodeWatchedHistory}"/>.</param>
+    /// <returns>IEnumerable{TraktEpisodeWatchedHistory}.</returns>
+    public static IEnumerable<TraktEpisodeWatchedHistory> FindAllMatches(Episode item, IEnumerable<TraktEpisodeWatchedHistory> results)
+    {
+        return results.Where(i => IsMatch(item, i.Episode)).AsEnumerable();
     }
 
     /// <summary>

--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -548,6 +548,11 @@ public static class Extensions
             return true;
         }
 
+        if (item.GetSeasonNumber() == episode.Season && item.ContainsEpisodeNumber(episode.Number))
+        {
+            return true;
+        }
+
         return false;
     }
 }

--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -559,26 +559,22 @@ public static class Extensions
     /// <returns><see cref="bool"/> indicating if the <see cref="Episode"/> matches a <see cref="TraktEpisodeWatchedHistory"/>.</returns>
     public static bool IsMatch(Episode item, TraktEpisodeWatchedHistory episodeHistory)
     {
-        // Match by provider id's
-        if (IsMatch(item, episodeHistory.Episode))
+        // Match by provider id's if available, Match by show, season and episode number if not
+        if (HasAnyProviderTvIds(item))
         {
-            return true;
+            return IsMatch(item, episodeHistory.Episode);
         }
-
-        // Match by show, season and episode number if no provider id's are available
-        if (!HasAnyProviderTvIds(item) && IsMatch(item.Series, episodeHistory.Show) && item.GetSeasonNumber() == episodeHistory.Episode.Season && item.ContainsEpisodeNumber(episodeHistory.Episode.Number))
+        else
         {
-            return true;
+            return IsMatch(item.Series, episodeHistory.Show) && item.GetSeasonNumber() == episodeHistory.Episode.Season && item.ContainsEpisodeNumber(episodeHistory.Episode.Number);
         }
-
-        return false;
     }
 
-    private static bool HasAnyProviderTvIds(BaseItem item)
+    private static bool HasAnyProviderTvIds(Episode item)
     {
-        return item.HasProviderId(MetadataProvider.Imdb)
-               || item.HasProviderId(MetadataProvider.Tmdb)
-               || item.HasProviderId(MetadataProvider.Tvdb)
-               || item.HasProviderId(MetadataProvider.TvRage);
+        return item.HasProviderId(MetadataProvider.Tvdb)
+            || item.HasProviderId(MetadataProvider.Tmdb)
+            || item.HasProviderId(MetadataProvider.Imdb)
+            || item.HasProviderId(MetadataProvider.TvRage);
     }
 }

--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -565,12 +565,24 @@ public static class Extensions
             return true;
         }
 
-        // Match by show, season and episode number
-        if (IsMatch(item.Series, episodeHistory.Show) && item.GetSeasonNumber() == episodeHistory.Episode.Season && item.ContainsEpisodeNumber(episodeHistory.Episode.Number))
+        // Match by show, season and episode number if there isn't any provider id in common
+        // If there was a common provider id between the item and the trakt episode (f.e. both have tvdb id), you shouldn't check anymore by season/number
+        if (HasAnyProviderTvIdInCommon(item, episodeHistory.Episode)
+            && IsMatch(item.Series, episodeHistory.Show)
+            && item.GetSeasonNumber() == episodeHistory.Episode.Season
+            && item.ContainsEpisodeNumber(episodeHistory.Episode.Number))
         {
             return true;
         }
 
         return false;
+    }
+
+    private static bool HasAnyProviderTvIdInCommon(Episode item, TraktEpisode traktEpisode)
+    {
+        return (item.HasProviderId(MetadataProvider.Tvdb) && traktEpisode.Ids.Tvdb != null)
+            || (item.HasProviderId(MetadataProvider.Imdb) && traktEpisode.Ids.Imdb != null)
+            || (item.HasProviderId(MetadataProvider.Tmdb) && traktEpisode.Ids.Tmdb != null)
+            || (item.HasProviderId(MetadataProvider.TvRage) && traktEpisode.Ids.Tvrage != null);
     }
 }

--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -559,30 +559,13 @@ public static class Extensions
     /// <returns><see cref="bool"/> indicating if the <see cref="Episode"/> matches a <see cref="TraktEpisodeWatchedHistory"/>.</returns>
     public static bool IsMatch(Episode item, TraktEpisodeWatchedHistory episodeHistory)
     {
-        var tvdb = item.GetProviderId(MetadataProvider.Tvdb);
-        if (!string.IsNullOrEmpty(tvdb) && string.Equals(tvdb, episodeHistory.Episode.Ids.Tvdb, StringComparison.OrdinalIgnoreCase))
+        // Match by provider id's
+        if (IsMatch(item, episodeHistory.Episode))
         {
             return true;
         }
 
-        var tmdb = item.GetProviderId(MetadataProvider.Tmdb);
-        if (!string.IsNullOrEmpty(tmdb) && string.Equals(tmdb, episodeHistory.Episode.Ids.Tmdb.ToString(), StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        var imdb = item.GetProviderId(MetadataProvider.Imdb);
-        if (!string.IsNullOrEmpty(imdb) && string.Equals(imdb, episodeHistory.Episode.Ids.Imdb, StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        var tvrage = item.GetProviderId(MetadataProvider.TvRage);
-        if (!string.IsNullOrEmpty(tvrage) && string.Equals(tvrage, episodeHistory.Episode.Ids.Tvrage, StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
+        // Match by show, season and episode number
         if (IsMatch(item.Series, episodeHistory.Show) && item.GetSeasonNumber() == episodeHistory.Episode.Season && item.ContainsEpisodeNumber(episodeHistory.Episode.Number))
         {
             return true;

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -320,7 +320,6 @@ public class SyncFromTraktTask : IScheduledTask
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var matchedWatchedShow = Extensions.FindMatch(episode.Series, traktWatchedShows);
-                var matchedWatchedEpisodeHistory = Extensions.FindAllMatches(episode, traktWatchedEpisodesHistory);
                 var matchedPausedEpisode = Extensions.FindMatch(episode, traktPausedEpisodes);
                 var userData = _userDataManager.GetUserData(user.Id, episode);
                 bool changed = false;
@@ -335,7 +334,9 @@ public class SyncFromTraktTask : IScheduledTask
                         tLastReset = resetValue;
                     }
 
-                    // Check if match is found in history, fallback to match by season and number if not
+                    var matchedWatchedEpisodeHistory = Extensions.FindAllMatches(episode, traktWatchedEpisodesHistory);
+
+                    // Check if match is found in history
                     if (matchedWatchedEpisodeHistory != null && matchedWatchedEpisodeHistory.Any())
                     {
                         // History is ordered with last watched first, so take the first one

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -399,7 +399,7 @@ public class SyncFromTraktTask : IScheduledTask
                             var playCount = matchedWatchedEpisodeHistory.Count();
                             if (userData.PlayCount < playCount)
                             {
-                                _logger.LogDebug("Adjusting episode's play count to match a higher remote value (remote: {Remote} | local: {Local}) for user {User} locally: {Data}", plays, userData.PlayCount, user.Username, GetVerboseEpisodeData(episode));
+                                _logger.LogDebug("Adjusting episode's play count to match a higher remote value (remote: {Remote} | local: {Local}) for user {User} locally: {Data}", playCount, userData.PlayCount, user.Username, GetVerboseEpisodeData(episode));
                                 userData.PlayCount = playCount;
                                 changed = true;
                             }

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities;
@@ -109,7 +110,7 @@ public class SyncFromTraktTask : IScheduledTask
         }
     }
 
-    private async Task SyncTraktDataForUser(Jellyfin.Data.Entities.User user, double currentProgress, IProgress<double> progress, double percentPerUser, CancellationToken cancellationToken)
+    private async Task SyncTraktDataForUser(User user, double currentProgress, IProgress<double> progress, double percentPerUser, CancellationToken cancellationToken)
     {
         var traktUser = UserHelper.GetTraktUser(user, true);
 
@@ -336,7 +337,7 @@ public class SyncFromTraktTask : IScheduledTask
                         tLastReset = resetValue;
                     }
 
-                    // Check is match is found via history, fallback to match by season and number
+                    // Check if match is found in history, fallback to match by season and number if not
                     if (matchedWatchedEpisodeHistory != null && matchedWatchedEpisodeHistory.Any())
                     {
                         // History is ordered with last watched first, so take the first one
@@ -462,7 +463,7 @@ public class SyncFromTraktTask : IScheduledTask
         while (previousCount != 0);
     }
 
-    private bool UpdateEpisodeData(Jellyfin.Data.Entities.User user, Episode episode, UserItemData userData, DateTime? tLastPlayed, int plays)
+    private bool UpdateEpisodeData(User user, Episode episode, UserItemData userData, DateTime? tLastPlayed, int plays)
     {
         bool changed = false;
 

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -355,7 +355,7 @@ public class SyncFromTraktTask : IScheduledTask
 
                         if (lastWatchedEpisodeHistory != null)
                         {
-                            _logger.LogDebug("Episode is in watched list of user {User}: {Data}", user.Username, GetVerboseEpisodeData(episode));
+                            _logger.LogDebug("Episode is in watched history list of user {User}: {Data}", user.Username, GetVerboseEpisodeData(episode));
 
                             episodeWatched = true;
                             DateTime? tLastPlayed = null;

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -368,39 +368,9 @@ public class SyncFromTraktTask : IScheduledTask
                             changed = UpdateEpisodeData(user, episode, userData, tLastPlayed, matchedWatchedEpisodeHistory.Count());
                         }
                     }
-                    else if (matchedWatchedSeason != null)
-                    {
-                        // Check for matching episodes including multi-episode entities
-                        var matchedWatchedEpisode = matchedWatchedSeason.Episodes.FirstOrDefault(x => episode.ContainsEpisodeNumber(x.Number));
-
-                        // Prepend a check if the matched episode is on a rewatch cycle and
-                        // discard it if the last play date was before the reset date
-                        if (matchedWatchedEpisode != null
-                            && tLastReset != null
-                            && DateTime.TryParse(matchedWatchedEpisode.LastWatchedAt, out var lastPlayedValue)
-                            && lastPlayedValue < tLastReset)
-                        {
-                            matchedWatchedEpisode = null;
-                        }
-
-                        if (matchedWatchedEpisode != null)
-                        {
-                            _logger.LogDebug("Episode is in watched list of user {User}: {Data}", user.Username, GetVerboseEpisodeData(episode));
-
-                            episodeWatched = true;
-                            DateTime? tLastPlayed = null;
-                            if (DateTime.TryParse(matchedWatchedEpisode.LastWatchedAt, out var lastWatchedValue))
-                            {
-                                tLastPlayed = lastWatchedValue;
-                            }
-
-                            // Update episode data
-                            changed = UpdateEpisodeData(user, episode, userData, tLastPlayed, matchedWatchedEpisode.Plays);
-                        }
-                    }
                     else
                     {
-                        _logger.LogDebug("No season data found for user {User} for {Data}", user.Username, GetVerboseEpisodeData(episode));
+                        _logger.LogDebug("No episode history data found for user {User} for {Data}", user.Username, GetVerboseEpisodeData(episode));
                     }
                 }
                 else

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -328,8 +328,6 @@ public class SyncFromTraktTask : IScheduledTask
 
                 if (!traktUser.SkipWatchedImportFromTrakt && matchedWatchedShow != null)
                 {
-                    var matchedWatchedSeason = matchedWatchedShow.Seasons.FirstOrDefault(tSeason => tSeason.Number == episode.GetSeasonNumber());
-
                     // Keep track of the shows rewatch cycles
                     DateTime? tLastReset = null;
                     if (DateTime.TryParse(matchedWatchedShow.ResetAt, out var resetValue))

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -319,7 +319,7 @@ public class SyncFromTraktTask : IScheduledTask
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var matchedWatchedShow = Extensions.FindMatch(episode.Series, traktWatchedShows);
-                var matchedWatchedEpisodeHistories = Extensions.FindAllMatches(episode, traktWatchedEpisodesHistory);
+                var matchedWatchedEpisodeHistory = Extensions.FindAllMatches(episode, traktWatchedEpisodesHistory);
                 var matchedPausedEpisode = Extensions.FindMatch(episode, traktPausedEpisodes);
                 var userData = _userDataManager.GetUserData(user.Id, episode);
                 bool changed = false;
@@ -337,10 +337,10 @@ public class SyncFromTraktTask : IScheduledTask
                     }
 
                     // Check is match is found via history, fallback to match by season and number
-                    if (matchedWatchedEpisodeHistories != null && matchedWatchedEpisodeHistories.Any())
+                    if (matchedWatchedEpisodeHistory != null && matchedWatchedEpisodeHistory.Any())
                     {
                         // History is ordered with last watched first, so take the first one
-                        var lastWatchedEpisodeHistory = matchedWatchedEpisodeHistories.FirstOrDefault();
+                        var lastWatchedEpisodeHistory = matchedWatchedEpisodeHistory.FirstOrDefault();
 
                         // Prepend a check if the matched episode is on a rewatch cycle and
                         // discard it if the last play date was before the reset date
@@ -364,7 +364,7 @@ public class SyncFromTraktTask : IScheduledTask
                             }
 
                             // Update episode data
-                            changed = UpdateEpisodeData(user, episode, userData, tLastPlayed, matchedWatchedEpisodeHistories.Count());
+                            changed = UpdateEpisodeData(user, episode, userData, tLastPlayed, matchedWatchedEpisodeHistory.Count());
                         }
                     }
                     else if (matchedWatchedSeason != null)


### PR DESCRIPTION
The history api includes more details (i.e. indexer id) which can be used to properly match episodes (i.e. when jellyfin is using other indexer than trakt). 
Matching by indexer id is a lot more accurate than matching by season and number. 
This is a rework of https://github.com/jellyfin/jellyfin-plugin-trakt/pull/191 where we are now using the history by default for episode sync.

@Shadowghost Maybe we can only use the history api for episode import from trakt?
Because I think that the history api will always find a match and there is no need anymore for fallback by season/number lookup.
Please provide your feedback. If you agree, I can cleanup the seaons/number logic for episode import and only import based on history api.
Or we just keep the legacy code as well, in case in future the trakt api for watched shows/episodes would contain the indexer id's.