### PR TITLE
Fix pagination when no items are present

### DIFF
--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -1136,7 +1136,7 @@ public class TraktApi
                     result.AddRange(tmpResult);
                 }
 
-                if (int.Parse(response.Headers.GetValues("X-Pagination-Page-Count").FirstOrDefault(page.ToString(CultureInfo.InvariantCulture)), CultureInfo.InvariantCulture) != page)
+                if (page < int.Parse(response.Headers.GetValues("X-Pagination-Page-Count").FirstOrDefault(page.ToString(CultureInfo.InvariantCulture)), CultureInfo.InvariantCulture))
                 {
                     page++;
                 }


### PR DESCRIPTION
I noticed an issue when setting this up on a fresh Trakt account. If you have nothing in your history, when you make a request to a page that supports pagination, the `X-Pagination-Page-Count` header value is set to 0. 

Since the check for pagination only checked that the count was not equal to the current page, and we start on page 1, this condition is never satisfied, spamming thousands of requests until eventually hitting the rate limits and stopping.

This changes the check so that if the current page is less than the total page count, we can continue requesting new pages.