### PR TITLE
Fix duplicate watched entries

### DIFF
--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -902,10 +902,10 @@ public class TraktApi
         foreach (TraktEpisode traktEpisode in traktSyncResponse.NotFound.Episodes.Where(episode => HasAnyProviderTvIds(episode.Ids)))
         {
             // Find matching episode in Jellyfin based on provider ids
-            var notFoundEpisode = episodeChunk.FirstOrDefault(episode => episode.GetProviderId(MetadataProvider.Imdb) == traktEpisode.Ids.Imdb
-                                                                         || episode.GetProviderId(MetadataProvider.Tmdb) == traktEpisode.Ids.Tmdb?.ToString(CultureInfo.InvariantCulture)
-                                                                         || episode.GetProviderId(MetadataProvider.Tvdb) == traktEpisode.Ids.Tvdb?.ToString(CultureInfo.InvariantCulture)
-                                                                         || episode.GetProviderId(MetadataProvider.TvRage) == traktEpisode.Ids.Tvrage?.ToString(CultureInfo.InvariantCulture));
+            var notFoundEpisode = episodeChunk.FirstOrDefault(episode => (!string.IsNullOrEmpty(episode.GetProviderId(MetadataProvider.Imdb)) && episode.GetProviderId(MetadataProvider.Imdb) == traktEpisode.Ids.Imdb)
+                                                                         || (!string.IsNullOrEmpty(episode.GetProviderId(MetadataProvider.Tmdb)) && episode.GetProviderId(MetadataProvider.Tmdb) == traktEpisode.Ids.Tmdb?.ToString(CultureInfo.InvariantCulture))
+                                                                         || (!string.IsNullOrEmpty(episode.GetProviderId(MetadataProvider.Tvdb)) && episode.GetProviderId(MetadataProvider.Tvdb) == traktEpisode.Ids.Tvdb?.ToString(CultureInfo.InvariantCulture))
+                                                                         || (!string.IsNullOrEmpty(episode.GetProviderId(MetadataProvider.TvRage)) && episode.GetProviderId(MetadataProvider.TvRage) == traktEpisode.Ids.Tvrage?.ToString(CultureInfo.InvariantCulture)));
 
             if (notFoundEpisode != null)
             {

--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -902,10 +902,15 @@ public class TraktApi
         foreach (TraktEpisode traktEpisode in traktSyncResponse.NotFound.Episodes.Where(episode => HasAnyProviderTvIds(episode.Ids)))
         {
             // Find matching episode in Jellyfin based on provider ids
-            var notFoundEpisode = episodeChunk.FirstOrDefault(episode => (!string.IsNullOrEmpty(episode.GetProviderId(MetadataProvider.Imdb)) && episode.GetProviderId(MetadataProvider.Imdb) == traktEpisode.Ids.Imdb)
-                                                                         || (!string.IsNullOrEmpty(episode.GetProviderId(MetadataProvider.Tmdb)) && episode.GetProviderId(MetadataProvider.Tmdb) == traktEpisode.Ids.Tmdb?.ToString(CultureInfo.InvariantCulture))
-                                                                         || (!string.IsNullOrEmpty(episode.GetProviderId(MetadataProvider.Tvdb)) && episode.GetProviderId(MetadataProvider.Tvdb) == traktEpisode.Ids.Tvdb?.ToString(CultureInfo.InvariantCulture))
-                                                                         || (!string.IsNullOrEmpty(episode.GetProviderId(MetadataProvider.TvRage)) && episode.GetProviderId(MetadataProvider.TvRage) == traktEpisode.Ids.Tvrage?.ToString(CultureInfo.InvariantCulture)));
+            var notFoundEpisode = episodeChunk.FirstOrDefault(episode =>
+                (episode.TryGetProviderId(MetadataProvider.Imdb, out var imdbId)
+                 && imdbId == traktEpisode.Ids.Imdb)
+                || (episode.TryGetProviderId(MetadataProvider.Tmdb, out var tmdbId)
+                    && tmdbId == traktEpisode.Ids.Tmdb?.ToString(CultureInfo.InvariantCulture))
+                || (episode.TryGetProviderId(MetadataProvider.Tvdb, out var tvdbId)
+                    && tvdbId == traktEpisode.Ids.Tvdb)
+                || (episode.TryGetProviderId(MetadataProvider.TvRage, out var tvRageId)
+                    && tvRageId == traktEpisode.Ids.Tvrage));
 
             if (notFoundEpisode != null)
             {


### PR DESCRIPTION
Previously, a missing episode with a null id could be matched to another episode from the same chunk that had a null id which would result it in the episode being added to trakt twice.

The code isn't the most idiomatic as I just threw it together to get this fixed.

Fixes #162
Fixes #219