### PR TITLE
Fix Trakt 3D metadata null value parsing

### DIFF
--- a/Trakt/Api/DataContracts/Sync/Collection/TraktEpisodeCollected.cs
+++ b/Trakt/Api/DataContracts/Sync/Collection/TraktEpisodeCollected.cs
@@ -43,7 +43,7 @@ public class TraktEpisodeCollected : TraktEpisode
     /// Gets or sets a value indicating whether the episode is 3D.
     /// </summary>
     [JsonPropertyName("3d")]
-    public bool Is3D { get; set; } = false;
+    public bool? Is3D { get; set; } = false;
 
     /// <summary>
     /// Gets or sets the HDR type.

--- a/Trakt/Api/DataContracts/Sync/Collection/TraktMovieCollected.cs
+++ b/Trakt/Api/DataContracts/Sync/Collection/TraktMovieCollected.cs
@@ -43,7 +43,7 @@ public class TraktMovieCollected : TraktMovie
     /// Gets or sets a value indicating whether the movie is 3D.
     /// </summary>
     [JsonPropertyName("3d")]
-    public bool Is3D { get; set; } = false;
+    public bool? Is3D { get; set; } = false;
 
     /// <summary>
     /// Gets or sets the HDR type.

--- a/Trakt/Api/DataContracts/Users/Collection/TraktMetadata.cs
+++ b/Trakt/Api/DataContracts/Users/Collection/TraktMetadata.cs
@@ -36,7 +36,7 @@ public class TraktMetadata
     /// Gets or sets a value indicating whether the movie is 3D.
     /// </summary>
     [JsonPropertyName("3d")]
-    public bool Is3D { get; set; } = false;
+    public bool? Is3D { get; set; } = false;
 
     /// <summary>
     /// Gets or sets the HDR type.


### PR DESCRIPTION
The Trakt scheduled tasks (Export and Import/Sync) crash instantly with a System.Text.Json.JsonException when pulling a user's collection if any item lacks explicitly defined 3D metadata. According to the official Trakt API documentation for the /users/{username}/collection endpoints, when ?extended=metadata is requested, the API "will use null if the metadata isn't set for an item." Because the parser currently strictly expects a boolean, this valid null response throws an InvalidOperationException and kills the sync worker. Fixes Issue #281.

I updated the data contracts representing the Trakt metadata object to use a nullable boolean for the 3d field. Changing public bool Is3D to public bool? Is3D allows the JSON parser to gracefully handle the API's documented null fallback state without crashing. This was applied to:
TraktMetadata.cs
TraktEpisodeCollected.cs
TraktMovieCollected.cs

Note, Gemini 3 Pro was used to find the root cause. 