### PR TITLE
 Fix MissingMethodException on Jellyfin 10.11 (use GetUsers() instead Users)

### DIFF
--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -79,7 +79,7 @@ public class SyncFromTraktTask : IScheduledTask
     /// <inheritdoc />
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
-        var users = _userManager.Users.Where(user => UserHelper.GetTraktUser(user, true) != null).ToList();
+        var users = _userManager.GetUsers().Where(user => UserHelper.GetTraktUser(user, true) != null).ToList();
 
         // No point going further if we don't have users.
         if (users.Count == 0)

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -83,7 +83,7 @@ public class SyncLibraryTask : IScheduledTask
     /// <inheritdoc />
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
-        var users = _userManager.Users.Where(u => UserHelper.GetTraktUser(u, true) != null).ToList();
+        var users = _userManager.GetUsers().Where(u => UserHelper.GetTraktUser(u, true) != null).ToList();
 
         // No point going further if we don't have users.
         if (users.Count == 0)


### PR DESCRIPTION
 IUserManager.Users was removed in Jellyfin 10.11 and replaced with GetUsers(). The v29 DLL still calls the old property, so on 10.11.9 both scheduled tasks crash immediately.

Verified on 10.11.9 with the patched DLL: Import completes, Export runs end-to-end.

While debugging I noticed current error handling makes this very hard to diagnose leading to 420 errors which when googling point to free account limits..