### PR TITLE
Fix watched movies/shows import only fetching the first page

### DIFF
--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -619,7 +619,7 @@ public class TraktApi
     /// <returns>Task{List{DataContracts.Users.Watched.TraktMovieWatched}}.</returns>
     public async Task<List<DataContracts.Users.Watched.TraktMovieWatched>> SendGetAllWatchedMoviesRequest(TraktUser traktUser)
     {
-        return await GetFromTrakt<List<DataContracts.Users.Watched.TraktMovieWatched>>(TraktUris.WatchedMovies, traktUser).ConfigureAwait(false);
+        return await GetFromTraktWithPaging<DataContracts.Users.Watched.TraktMovieWatched>(TraktUris.WatchedMovies, traktUser).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -629,7 +629,7 @@ public class TraktApi
     /// <returns>Task{List{DataContracts.Users.Watched.TraktShowWatched}}.</returns>
     public async Task<List<DataContracts.Users.Watched.TraktShowWatched>> SendGetWatchedShowsRequest(TraktUser traktUser)
     {
-        return await GetFromTrakt<List<DataContracts.Users.Watched.TraktShowWatched>>(TraktUris.WatchedShows, traktUser).ConfigureAwait(false);
+        return await GetFromTraktWithPaging<DataContracts.Users.Watched.TraktShowWatched>(TraktUris.WatchedShows, traktUser).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Trakt/Api/TraktURIs.cs
+++ b/Trakt/Api/TraktURIs.cs
@@ -93,12 +93,12 @@ public static class TraktUris
     /// <summary>
     /// The watched movies URI.
     /// </summary>
-    public const string WatchedMovies = BaseUrl + "/sync/watched/movies";
+    public const string WatchedMovies = BaseUrl + "/sync/watched/movies?page={page}&limit=1000";
 
     /// <summary>
     /// The watched shows URI.
     /// </summary>
-    public const string WatchedShows = BaseUrl + "/sync/watched/shows";
+    public const string WatchedShows = BaseUrl + "/sync/watched/shows?page={page}&limit=1000";
 
     /// <summary>
     /// The paused movies URI.


### PR DESCRIPTION
## Problem

Importing watched state from Trakt only marks a small subset of items as played, even when the matching library items exist and are watched on Trakt. On an account with ~870 watched movies, only ~100 are ever imported.

## Cause

`SendGetAllWatchedMoviesRequest` and `SendGetWatchedShowsRequest` fetch `/sync/watched/movies` and `/sync/watched/shows` via `GetFromTrakt`, which issues a **single** request and ignores pagination. Trakt paginates these endpoints — the response carries `X-Pagination-*` headers, defaults to 100 items/page and caps `limit` at 250 — so only the first page is imported. Everything past the first page stays unmarked in Jellyfin.

By contrast, the history endpoints already use `GetFromTraktWithPaging`, which loops until `X-Pagination-Page-Count` is exhausted.

Observed against the live API for an account with 872 watched movies:

```
GET /sync/watched/movies            -> X-Pagination-Item-Count: 872, Limit: 100, Page-Count: 9  (body: 100 items)
GET /sync/watched/movies?limit=1000 -> X-Pagination-Item-Count: 872, Limit: 250, Page-Count: 4  (body: 250 items)
```

## Fix

- Switch both watched requests to the existing `GetFromTraktWithPaging<T>` helper.
- Add `?page={page}&limit=1000` to the two URIs (mirrors the existing history URIs; Trakt clamps `limit` to 250 and the paging loop walks the remaining pages via `X-Pagination-Page-Count`).

Public method signatures are unchanged (`List<TraktMovieWatched>` / `List<TraktShowWatched>`).

## Notes

`CollectedMovies`/`CollectedShows`/`PausedMovies` use the same non-paged `GetFromTrakt` pattern and may be affected on large libraries, but I kept this PR scoped to the reported watched-state bug.