### PR TITLE
Fix episode external URL generation

### DIFF
--- a/Trakt/ExternalUrlProvider.cs
+++ b/Trakt/ExternalUrlProvider.cs
@@ -31,7 +31,13 @@ public class ExternalUrlProvider : IExternalUrlProvider
                 yield return $"https://trakt.tv/movies/{imdbId}";
                 break;
             case Episode episode:
-                yield return $"https://trakt.tv/shows/{episode.SeriesName}/seasons/{episode.ParentIndexNumber}/episodes/{episode.IndexNumber}";
+                var showimbdId = episode.Series.GetProviderId(MetadataProvider.Imdb);
+                if (string.IsNullOrEmpty(showimbdId))
+                {
+                    yield break;
+                }
+
+                yield return $"https://trakt.tv/shows/{showimbdId}/seasons/{episode.ParentIndexNumber}/episodes/{episode.IndexNumber}";
                 break;
             case Series:
                 yield return $"https://trakt.tv/shows/{imdbId}";

--- a/Trakt/ExternalUrlProvider.cs
+++ b/Trakt/ExternalUrlProvider.cs
@@ -30,8 +30,8 @@ public class ExternalUrlProvider : IExternalUrlProvider
             case Movie or Trailer or LiveTvProgram { IsMovie: true }:
                 yield return $"https://trakt.tv/movies/{imdbId}";
                 break;
-            case Episode:
-                yield return $"https://trakt.tv/episodes/{imdbId}";
+            case Episode episode:
+                yield return $"https://trakt.tv/shows/{episode.SeriesName}/seasons/{episode.ParentIndexNumber}/episodes/{episode.IndexNumber}";
                 break;
             case Series:
                 yield return $"https://trakt.tv/shows/{imdbId}";


### PR DESCRIPTION
The issue was that the plugin was building Trakt episode links using the direct IMDb ID path, but that URL format no longer works reliably for episode pages. As a result, clicking the external link redirects to the main page only.

Reference:
https://docs.trakt.tv/docs/website-media-links