### PR TITLE
Fix duplicate watched-history plays for shows with local/trakt numbering mismatches

### DIFF
--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -435,7 +435,7 @@ public static class Extensions
     /// <returns>TraktEpisodeWatchedHistory.</returns>
     public static TraktEpisodeWatchedHistory FindMatch(Episode item, IEnumerable<TraktEpisodeWatchedHistory> results)
     {
-        return results.FirstOrDefault(i => IsMatch(item, i.Episode));
+        return results.FirstOrDefault(i => IsMatch(item, i));
     }
 
     /// <summary>

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -18,6 +18,7 @@ using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 using Trakt.Api;
 using Trakt.Api.DataContracts.Sync;
+using Trakt.Api.DataContracts.Sync.History;
 using Trakt.Api.Enums;
 using Trakt.Helpers;
 using Trakt.Model;
@@ -384,6 +385,7 @@ public class SyncLibraryTask : IScheduledTask
         CancellationToken cancellationToken)
     {
         List<Api.DataContracts.Users.Watched.TraktShowWatched> traktWatchedShows = new List<Api.DataContracts.Users.Watched.TraktShowWatched>();
+        List<TraktEpisodeWatchedHistory> traktWatchedEpisodesHistory = new List<TraktEpisodeWatchedHistory>();
         List<Api.DataContracts.Users.Collection.TraktShowCollected> traktCollectedShows = new List<Api.DataContracts.Users.Collection.TraktShowCollected>();
 
         try
@@ -395,6 +397,7 @@ public class SyncLibraryTask : IScheduledTask
             if (traktUser.PostWatchedHistory || traktUser.PostUnwatchedHistory)
             {
                 traktWatchedShows.AddRange(await _traktApi.SendGetWatchedShowsRequest(traktUser).ConfigureAwait(false));
+                traktWatchedEpisodesHistory.AddRange(await _traktApi.SendGetWatchedEpisodesHistoryRequest(traktUser).ConfigureAwait(false));
             }
 
             if (traktUser.SynchronizeCollections)
@@ -453,6 +456,14 @@ public class SyncLibraryTask : IScheduledTask
                                     && season.Episodes != null
                                     && season.Episodes.Any(e => episode.ContainsEpisodeNumber(e.Number)
                                         && e.Plays > 0));
+                        }
+
+                        // Local season/episode numbering can differ from trakt.tv's structure
+                        // (e.g. absolute-numbered anime), so also match by provider ids against
+                        // the watched history before treating the episode as unplayed.
+                        if (!isPlayedTraktTv && Extensions.FindMatch(episode, traktWatchedEpisodesHistory) != null)
+                        {
+                            isPlayedTraktTv = true;
                         }
 
                         // If the show has been played locally and is unplayed on trakt.tv then add it to the list

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -447,7 +447,7 @@ public class SyncLibraryTask : IScheduledTask
                     var isPlayedTraktTv = false;
                     var traktWatchedShow = Extensions.FindMatch(episode.Series, traktWatchedShows);
 
-                    if (traktUser.PostSetUnwatched || traktUser.PostSetWatched)
+                    if (traktUser.PostWatchedHistory || traktUser.PostUnwatchedHistory)
                     {
                         if (traktWatchedShow?.Seasons != null && traktWatchedShow.Seasons.Count > 0)
                         {


### PR DESCRIPTION
The export task decided whether an episode was already watched on trakt.tv solely by comparing local season/episode numbers against the watched-shows structure. When local numbering differs from trakt.tv's (e.g. absolute-numbered anime where the local library has S01E67 but trakt.tv uses S03E17), the comparison never matches and the episode is re-added to the watched history on every scheduled export run, producing duplicate plays and inflated stats.

This adds a fallback that matches by provider ids (imdb/tmdb/tvdb/tvrage) against the watched-episodes history before treating an episode as unplayed — the same provider-id-first, numbering-fallback matching the import task (`SyncFromTraktTask`) already uses for the equivalent operation.

Also fixes the block's gating condition: it checked `PostSetWatched`/`PostSetUnwatched` (the real-time scrobble flags) instead of `PostWatchedHistory`/`PostUnwatchedHistory` (the scheduled-task flags the surrounding data fetch and the inner add-to-list logic already use), so this entire section silently did nothing for users who have scheduled export enabled but instant sync disabled.

Diagnosed against a real Jellyfin 10.11 install where a ~200-episode absolute-numbered anime library was re-pushing duplicate watched-history entries to trakt.tv every day because of this exact numbering mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)