### PR TITLE
Fix a null-check gap and two exception-swallowing bugs in the sync/API layer

### DIFF
--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -932,7 +932,8 @@ public class TraktApi
     /// Deauthorizes a device for a <see cref="TraktUser"/>.
     /// </summary>
     /// <param name="traktUser">The authorizing <see cref="TraktUser"/>.</param>
-    public async void DeauthorizeDevice(TraktUser traktUser)
+    /// <returns>Task.</returns>
+    public async Task DeauthorizeDevice(TraktUser traktUser)
     {
         var deviceRevokeRequest = new
         {
@@ -941,7 +942,15 @@ public class TraktApi
             client_secret = TraktUris.ClientSecret
         };
 
-        await PostToTrakt<object>(TraktUris.RevokeToken, deviceRevokeRequest, traktUser).ConfigureAwait(false);
+        try
+        {
+            await PostToTrakt<object>(TraktUris.RevokeToken, deviceRevokeRequest, traktUser).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Revoking on trakt.tv is best-effort; the caller removes the local user
+            // regardless, and PostToTrakt already logged the underlying failure.
+        }
     }
 
     /// <summary>
@@ -1227,6 +1236,7 @@ public class TraktApi
     private async Task<HttpResponseMessage> RetryHttpRequest(Func<Task<HttpResponseMessage>> function)
     {
         HttpResponseMessage response = null;
+        Exception lastException = null;
         for (int i = 0; i < 3; i++)
         {
             try
@@ -1252,9 +1262,17 @@ public class TraktApi
                     break;
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                lastException = ex;
+                response = null;
+                _logger.LogDebug(ex, "Trakt request attempt {Attempt} of 3 failed", i + 1);
             }
+        }
+
+        if (response == null && lastException != null)
+        {
+            throw lastException;
         }
 
         return response;

--- a/Trakt/Api/TraktController.cs
+++ b/Trakt/Api/TraktController.cs
@@ -91,7 +91,7 @@ public class TraktController : ControllerBase
     [HttpPost("Users/{userGuid}/Deauthorize")]
     [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public string TraktDeviceDeAuthorization([FromRoute] Guid userGuid)
+    public async Task<string> TraktDeviceDeAuthorization([FromRoute] Guid userGuid)
     {
         _logger.LogInformation("TraktDeviceDeauthorization request received");
 
@@ -103,7 +103,7 @@ public class TraktController : ControllerBase
         }
         else
         {
-            _traktApi.DeauthorizeDevice(traktUser);
+            await _traktApi.DeauthorizeDevice(traktUser).ConfigureAwait(false);
             Plugin.Instance.PluginConfiguration.RemoveUser(userGuid);
             Plugin.Instance.SaveConfiguration();
         }

--- a/Trakt/Helpers/LibraryManagerEventsHelper.cs
+++ b/Trakt/Helpers/LibraryManagerEventsHelper.cs
@@ -203,7 +203,7 @@ internal sealed class LibraryManagerEventsHelper : IDisposable
                               || !string.IsNullOrEmpty(lev.GetProviderId(MetadataProvider.Tvdb))
                               || !string.IsNullOrEmpty(lev.GetProviderId(MetadataProvider.Imdb))
                               || !string.IsNullOrEmpty(lev.GetProviderId(MetadataProvider.TvRage)))
-                          && !traktUser.LocationsExcluded.Any(directory => lev.Path.Contains(directory, StringComparison.OrdinalIgnoreCase)))
+                          && (traktUser.LocationsExcluded == null || !traktUser.LocationsExcluded.Any(directory => lev.Path.Contains(directory, StringComparison.OrdinalIgnoreCase))))
             .ToHashSet();
 
         try
@@ -241,7 +241,7 @@ internal sealed class LibraryManagerEventsHelper : IDisposable
             .Where(movie => !string.IsNullOrEmpty(movie.Name)
                           && (!string.IsNullOrEmpty(movie.GetProviderId(MetadataProvider.Tmdb))
                               || !string.IsNullOrEmpty(movie.GetProviderId(MetadataProvider.Imdb)))
-                          && !traktUser.LocationsExcluded.Any(directory => movie.Path is not null && movie.Path.Contains(directory, StringComparison.OrdinalIgnoreCase)))
+                          && (traktUser.LocationsExcluded == null || !traktUser.LocationsExcluded.Any(directory => movie.Path is not null && movie.Path.Contains(directory, StringComparison.OrdinalIgnoreCase))))
             .ToHashSet();
 
         try
@@ -278,7 +278,7 @@ internal sealed class LibraryManagerEventsHelper : IDisposable
                             && !string.IsNullOrEmpty(lev.Series.Name)
                             && (!string.IsNullOrEmpty(lev.Series.GetProviderId(MetadataProvider.Tmdb))
                                 || !string.IsNullOrEmpty(lev.GetProviderId(MetadataProvider.Tvdb)))
-                            && !traktUser.LocationsExcluded.Any(directory => lev.Path.Contains(directory, StringComparison.OrdinalIgnoreCase)))
+                            && (traktUser.LocationsExcluded == null || !traktUser.LocationsExcluded.Any(directory => lev.Path.Contains(directory, StringComparison.OrdinalIgnoreCase))))
                 .OrderBy(i => i.Series.Id)
                 .ToList();
 


### PR DESCRIPTION
Three small, independent hardening fixes found while auditing the sync pipeline:

- `LibraryManagerEventsHelper`'s `ProcessQueuedMovieEvents`/`ProcessQueuedShowEvents`/`ProcessQueuedEpisodeEvents` dereferenced `traktUser.LocationsExcluded` without the null check `TraktApi.CanSync` already uses. `LocationsExcluded` is null by default until a user saves the excluded-locations settings page, so queuing any item for a freshly linked user threw a `NullReferenceException` when the queue flushed — for the movie/show variants this happened outside the method's own try/catch, aborting that whole processing cycle for every other configured user.
- `TraktApi.DeauthorizeDevice` was `async void` with nothing awaiting or catching it, while `PostToTrakt` logs and rethrows on failure. A revoke that failed (trakt.tv unreachable, rate-limited, already-invalid token) became an unhandled exception with no catch anywhere in the chain — which can crash the whole Jellyfin process rather than just failing the deauthorization. Changed to `async Task`, caught internally since revocation is best-effort and local deauthorization should proceed regardless.
- `RetryHttpRequest` silently swallowed every exception and could return `null` after exhausting all 3 attempts; every caller immediately dereferenced `response.StatusCode`, turning a real connectivity failure into a misleading `NullReferenceException`. Now logs each failed attempt and rethrows the last exception instead of returning null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)